### PR TITLE
Update README to include GHAS instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ jobs:
         uses: actions/dependency-review-action@v1
 ```
 
+Please keep in mind that you need a GitHub Advanced Security license if you're running this Action on private repos.
+
 ## Getting help
 
 If you have bug reports, questions or suggestions please [create a new


### PR DESCRIPTION
Minor tweak to the README so folks are aware that a GHAS license is needed for private repos. Closes #41.