### PR TITLE
Unknown licenses

### DIFF
--- a/src/licenses.ts
+++ b/src/licenses.ts
@@ -26,7 +26,6 @@ export function getDeniedLicenseChanges(
 
   for (const change of changes) {
     let license = change.license
-    // TODO: be loud about unknown licenses
     if (license === null) {
       unknown.push(change)
       continue

--- a/src/main.ts
+++ b/src/main.ts
@@ -59,9 +59,10 @@ async function run(): Promise<void> {
 
     if (licenseErrors.length > 0) {
       printLicensesError(licenseErrors, licenses)
-      printNullLicenses(unknownLicenses)
       core.setFailed('Dependency review detected incompatible licenses.')
     }
+
+    printNullLicenses(unknownLicenses)
 
     if (failed) {
       core.setFailed('Dependency review detected vulnerable packages.')


### PR DESCRIPTION
Previously we only showed the message about null licenses when the licenses check failed. With this change it will be shown on every case so users are aware.