### PR TITLE
Use fixed major version for node types

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,6 @@ updates:
     directory: /
     schedule:
       interval: daily
+    ignore:
+      - dependency-name: '@types/*'
+        update-types: ['version-update:semver-major']

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,5 +10,5 @@ updates:
     schedule:
       interval: daily
     ignore:
-      - dependency-name: '@types/*'
+      - dependency-name: '@types/node'
         update-types: ['version-update:semver-major']

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "zod": "^3.17.3"
       },
       "devDependencies": {
-        "@types/node": "^18.0.0",
+        "@types/node": "^16.11.43",
         "@typescript-eslint/eslint-plugin": "^5.30.0",
         "@typescript-eslint/parser": "^5.30.0",
         "@vercel/ncc": "^0.34.0",
@@ -1366,9 +1366,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.0.0.tgz",
-      "integrity": "sha512-cHlGmko4gWLVI27cGJntjs/Sj8th9aYwplmZFwmmgYQQvL5NUsgVJG7OddLvNfLqYS31KFN0s3qlaD9qCaxACA=="
+      "version": "16.11.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.43.tgz",
+      "integrity": "sha512-GqWykok+3uocgfAJM8imbozrqLnPyTrpFlrryURQlw1EesPUCx5XxTiucWDSFF9/NUEXDuD4bnvHm8xfVGWTpQ=="
     },
     "node_modules/@types/prettier": {
       "version": "2.4.4",
@@ -8555,9 +8555,9 @@
       }
     },
     "@types/node": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.0.0.tgz",
-      "integrity": "sha512-cHlGmko4gWLVI27cGJntjs/Sj8th9aYwplmZFwmmgYQQvL5NUsgVJG7OddLvNfLqYS31KFN0s3qlaD9qCaxACA=="
+      "version": "16.11.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.43.tgz",
+      "integrity": "sha512-GqWykok+3uocgfAJM8imbozrqLnPyTrpFlrryURQlw1EesPUCx5XxTiucWDSFF9/NUEXDuD4bnvHm8xfVGWTpQ=="
     },
     "@types/prettier": {
       "version": "2.4.4",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "zod": "^3.17.3"
   },
   "devDependencies": {
-    "@types/node": "^18.0.0",
+    "@types/node": "^16.11.43",
     "@typescript-eslint/eslint-plugin": "^5.30.0",
     "@typescript-eslint/parser": "^5.30.0",
     "@vercel/ncc": "^0.34.0",


### PR DESCRIPTION
This action works under node 16, is types only updating to node 18 intentional? 👀  https://github.com/actions/dependency-review-action/blob/26b790870174b01a5110cc2be9ad84ec2374e5b5/action.yml#L20
https://github.com/actions/dependency-review-action/blob/26b790870174b01a5110cc2be9ad84ec2374e5b5/.github/workflows/check-dist.yml#L26-L29

ref: https://github.com/actions/dependency-review-action/pull/137