### PR TITLE
Fix passing repo-token input in scan_pr script

### DIFF
--- a/scripts/scan_pr
+++ b/scripts/scan_pr
@@ -32,17 +32,23 @@ event_file = Tempfile.new
 event_file.write("{ \"pull_request\": #{pr.to_h.to_json}}")
 event_file.close
 
-dev_cmd_env = {
-  "INPUT_REPO-TOKEN" => github_token,
-  "GITHUB_REPOSITORY" => repo_nwo,
-  "GITHUB_EVENT_NAME" => "pull_request",
-  "GITHUB_EVENT_PATH" => event_file.path
+action_inputs = {
+  "repo-token" => github_token
 }
 
-dev_cmd = "./node_modules/.bin/nodemon --exec \"node -r esbuild-register\" src/main.ts"
+dev_cmd_env = {
+  "GITHUB_REPOSITORY" => repo_nwo,
+  "GITHUB_EVENT_NAME" => "pull_request",
+  "GITHUB_EVENT_PATH" => event_file.path,
+  "GITHUB_STEP_SUMMARY" => "/dev/null"
+}
+
+action_inputs_env_str = action_inputs.map { |name, value| "\"INPUT_#{name.upcase}=#{value}\"" }.join(" ")
+
+dev_cmd = "./node_modules/.bin/nodemon --exec \"env #{action_inputs_env_str} node -r esbuild-register\" src/main.ts"
 
 Open3.popen2e(dev_cmd_env, dev_cmd) do |stdin, out|
   while line = out.gets
-    puts line
+    puts line.gsub(github_token, "<REDACTED>")
   end
 end

--- a/scripts/scan_pr
+++ b/scripts/scan_pr
@@ -43,8 +43,10 @@ dev_cmd_env = {
   "GITHUB_STEP_SUMMARY" => "/dev/null"
 }
 
+# bash does not like variable names with dashes like the ones Actions
+# uses (e.g. INPUT_REPO-TOKEN). Passing them through `env` instead of
+# manually setting them does the job.
 action_inputs_env_str = action_inputs.map { |name, value| "\"INPUT_#{name.upcase}=#{value}\"" }.join(" ")
-
 dev_cmd = "./node_modules/.bin/nodemon --exec \"env #{action_inputs_env_str} node -r esbuild-register\" src/main.ts"
 
 Open3.popen2e(dev_cmd_env, dev_cmd) do |stdin, out|


### PR DESCRIPTION
This PR takes care of two existing issues with `script/scan_pr`:

1. `GITHUB_STEP_SUMMARY` was previously not defined, which raised an error at the end of every run of the script.
2. Bash 5 in Linux does not accept variables with dashes (e.g. `INPUT_REPO-TOKEN`). With these changes we pass the variable values through `env` when calling `nodemon`.