### PR TITLE
Updating action.yml to include `*-check` config options

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -35,6 +35,14 @@ inputs:
   external-repo-token:
     description: A token for fetching external configuration file if it lives in another repository. It is required if the repository is private
     required: false
+  license-check:
+    description: A boolean to determine if license checks should be performed
+    required: false
+    default: true
+  vulnerability-check:
+    description: A boolean to determine if vulnerability checks should be performed
+    required: false
+    default: true
 
 runs:
   using: 'node16'


### PR DESCRIPTION
We need to add `license-check` and `vulnerability-check` to `action.yml` in order to be able to use these in external config files.