### PR TITLE
Fix default values for fail-on-severity

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,8 @@ Start by specifying that you will be using an external configuration file:
     config-file: './.github/dependency-review-config.yml'
 ```
 
-And then create the file in the path you just specified:
+And then create the file in the path you just specified. Please note
+that the **option names in external files use underscores instead of dashes**:
 
 ```yaml
 fail_on_severity: 'critical'

--- a/README.md
+++ b/README.md
@@ -131,8 +131,8 @@ Start by specifying that you will be using an external configuration file:
 And then create the file in the path you just specified:
 
 ```yaml
-fail-on-severity: 'critical'
-allow-licenses:
+fail_on_severity: 'critical'
+allow_licenses:
   - 'GPL-3.0'
   - 'BSD-3-Clause'
   - 'MIT'

--- a/__tests__/config.test.ts
+++ b/__tests__/config.test.ts
@@ -2,35 +2,7 @@ import {expect, test, beforeEach} from '@jest/globals'
 import {readConfig} from '../src/config'
 import {getRefs} from '../src/git-refs'
 import * as Utils from '../src/utils'
-
-// GitHub Action inputs come in the form of environment variables
-// with an INPUT prefix (e.g. INPUT_FAIL-ON-SEVERITY)
-function setInput(input: string, value: string): void {
-  process.env[`INPUT_${input.toUpperCase()}`] = value
-}
-
-// We want a clean ENV before each test. We use `delete`
-// since we want `undefined` values and not empty strings.
-function clearInputs(): void {
-  const allowedOptions = [
-    'FAIL-ON-SEVERITY',
-    'FAIL-ON-SCOPES',
-    'ALLOW-LICENSES',
-    'DENY-LICENSES',
-    'ALLOW-GHSAS',
-    'LICENSE-CHECK',
-    'VULNERABILITY-CHECK',
-    'CONFIG-FILE',
-    'BASE-REF',
-    'HEAD-REF',
-    'COMMENT-SUMMARY-IN-PR'
-  ]
-
-  // eslint-disable-next-line github/array-foreach
-  allowedOptions.forEach(option => {
-    delete process.env[`INPUT_${option.toUpperCase()}`]
-  })
-}
+import {setInput, clearInputs} from './test-helpers'
 
 beforeAll(() => {
   jest.spyOn(Utils, 'isSPDXValid').mockReturnValue(true)

--- a/__tests__/config.test.ts
+++ b/__tests__/config.test.ts
@@ -1,6 +1,6 @@
-import { expect, test, beforeEach } from '@jest/globals'
-import { readConfig } from '../src/config'
-import { getRefs } from '../src/git-refs'
+import {expect, test, beforeEach} from '@jest/globals'
+import {readConfig} from '../src/config'
+import {getRefs} from '../src/git-refs'
 import * as Utils from '../src/utils'
 
 // GitHub Action inputs come in the form of environment variables

--- a/__tests__/config.test.ts
+++ b/__tests__/config.test.ts
@@ -1,6 +1,6 @@
-import {expect, test, beforeEach} from '@jest/globals'
-import {readConfig} from '../src/config'
-import {getRefs} from '../src/git-refs'
+import { expect, test, beforeEach } from '@jest/globals'
+import { readConfig } from '../src/config'
+import { getRefs } from '../src/git-refs'
 import * as Utils from '../src/utils'
 
 // GitHub Action inputs come in the form of environment variables
@@ -105,60 +105,6 @@ test('it raises an error when no refs are provided and the event is not a pull r
   ).toThrow()
 })
 
-test('it reads an external config file', async () => {
-  setInput('config-file', './__tests__/fixtures/config-allow-sample.yml')
-
-  const config = await readConfig()
-  expect(config.fail_on_severity).toEqual('critical')
-  expect(config.allow_licenses).toEqual(['BSD', 'GPL 2'])
-})
-
-test('raises an error when the config file was not found', async () => {
-  setInput('config-file', 'fixtures/i-dont-exist')
-  await expect(readConfig()).rejects.toThrow(/Unable to fetch/)
-})
-
-test('it parses options from both sources', async () => {
-  setInput('config-file', './__tests__/fixtures/config-allow-sample.yml')
-
-  let config = await readConfig()
-  expect(config.fail_on_severity).toEqual('critical')
-
-  setInput('base-ref', 'a-custom-base-ref')
-  config = await readConfig()
-  expect(config.base_ref).toEqual('a-custom-base-ref')
-})
-
-test('in case of conflicts, the inline config is the source of truth', async () => {
-  setInput('fail-on-severity', 'low')
-  setInput('config-file', './__tests__/fixtures/config-allow-sample.yml') // this will set fail-on-severity to 'critical'
-
-  const config = await readConfig()
-  expect(config.fail_on_severity).toEqual('low')
-})
-
-test('it uses the default values when loading external files', async () => {
-  setInput('config-file', './__tests__/fixtures/no-licenses-config.yml')
-  let config = await readConfig()
-  expect(config.allow_licenses).toEqual(undefined)
-  expect(config.deny_licenses).toEqual(undefined)
-
-  setInput('config-file', './__tests__/fixtures/license-config-sample.yml')
-  config = await readConfig()
-  expect(config.fail_on_severity).toEqual('low')
-})
-
-test('it accepts an external configuration filename', async () => {
-  setInput('config-file', './__tests__/fixtures/no-licenses-config.yml')
-  const config = await readConfig()
-  expect(config.fail_on_severity).toEqual('critical')
-})
-
-test('it raises an error when given an unknown severity in an external config file', async () => {
-  setInput('config-file', './__tests__/fixtures/invalid-severity-config.yml')
-  await expect(readConfig()).rejects.toThrow()
-})
-
 test('it defaults to runtime scope', async () => {
   const config = await readConfig()
   expect(config.fail_on_scopes).toEqual(['runtime'])
@@ -232,16 +178,6 @@ test('it is not possible to disable both checks', async () => {
   await expect(readConfig()).rejects.toThrow(
     /Can't disable both license-check and vulnerability-check/
   )
-})
-
-test('it supports comma-separated lists', async () => {
-  setInput(
-    'config-file',
-    './__tests__/fixtures/inline-license-config-sample.yml'
-  )
-  const config = await readConfig()
-
-  expect(config.allow_licenses).toEqual(['MIT', 'GPL-2.0-only'])
 })
 
 describe('licenses that are not valid SPDX licenses', () => {

--- a/__tests__/external-config.test.ts
+++ b/__tests__/external-config.test.ts
@@ -1,35 +1,7 @@
 import {expect, test, beforeEach} from '@jest/globals'
 import {readConfig} from '../src/config'
 import * as Utils from '../src/utils'
-
-// GitHub Action inputs come in the form of environment variables
-// with an INPUT prefix (e.g. INPUT_FAIL-ON-SEVERITY)
-function setInput(input: string, value: string): void {
-  process.env[`INPUT_${input.toUpperCase()}`] = value
-}
-
-// We want a clean ENV before each test. We use `delete`
-// since we want `undefined` values and not empty strings.
-function clearInputs(): void {
-  const allowedOptions = [
-    'FAIL-ON-SEVERITY',
-    'FAIL-ON-SCOPES',
-    'ALLOW-LICENSES',
-    'DENY-LICENSES',
-    'ALLOW-GHSAS',
-    'LICENSE-CHECK',
-    'VULNERABILITY-CHECK',
-    'CONFIG-FILE',
-    'BASE-REF',
-    'HEAD-REF',
-    'COMMENT-SUMMARY-IN-PR'
-  ]
-
-  // eslint-disable-next-line github/array-foreach
-  allowedOptions.forEach(option => {
-    delete process.env[`INPUT_${option.toUpperCase()}`]
-  })
-}
+import {setInput, clearInputs} from './test-helpers'
 
 const externalConfig = `fail_on_severity: 'high'
 allow_licenses: ['GPL-2.0-only']

--- a/__tests__/external-config.test.ts
+++ b/__tests__/external-config.test.ts
@@ -1,0 +1,104 @@
+import { expect, test, beforeEach } from '@jest/globals'
+import { readConfig } from '../src/config'
+import * as Utils from '../src/utils'
+
+// GitHub Action inputs come in the form of environment variables
+// with an INPUT prefix (e.g. INPUT_FAIL-ON-SEVERITY)
+function setInput(input: string, value: string): void {
+  process.env[`INPUT_${input.toUpperCase()}`] = value
+}
+
+// We want a clean ENV before each test. We use `delete`
+// since we want `undefined` values and not empty strings.
+function clearInputs(): void {
+  const allowedOptions = [
+    'FAIL-ON-SEVERITY',
+    'FAIL-ON-SCOPES',
+    'ALLOW-LICENSES',
+    'DENY-LICENSES',
+    'ALLOW-GHSAS',
+    'LICENSE-CHECK',
+    'VULNERABILITY-CHECK',
+    'CONFIG-FILE',
+    'BASE-REF',
+    'HEAD-REF',
+    'COMMENT-SUMMARY-IN-PR'
+  ]
+
+  // eslint-disable-next-line github/array-foreach
+  allowedOptions.forEach(option => {
+    delete process.env[`INPUT_${option.toUpperCase()}`]
+  })
+}
+
+beforeAll(() => {
+  jest.spyOn(Utils, 'isSPDXValid').mockReturnValue(true)
+})
+
+beforeEach(() => {
+  clearInputs()
+})
+
+test('it reads an external config file', async () => {
+  setInput('config-file', './__tests__/fixtures/config-allow-sample.yml')
+
+  const config = await readConfig()
+  expect(config.fail_on_severity).toEqual('critical')
+  expect(config.allow_licenses).toEqual(['BSD', 'GPL 2'])
+})
+
+test('raises an error when the config file was not found', async () => {
+  setInput('config-file', 'fixtures/i-dont-exist')
+  await expect(readConfig()).rejects.toThrow(/Unable to fetch/)
+})
+
+test('it parses options from both sources', async () => {
+  setInput('config-file', './__tests__/fixtures/config-allow-sample.yml')
+
+  let config = await readConfig()
+  expect(config.fail_on_severity).toEqual('critical')
+
+  setInput('base-ref', 'a-custom-base-ref')
+  config = await readConfig()
+  expect(config.base_ref).toEqual('a-custom-base-ref')
+})
+
+test('in case of conflicts, the inline config is the source of truth', async () => {
+  setInput('fail-on-severity', 'low')
+  setInput('config-file', './__tests__/fixtures/config-allow-sample.yml') // this will set fail-on-severity to 'critical'
+
+  const config = await readConfig()
+  expect(config.fail_on_severity).toEqual('low')
+})
+
+test('it uses the default values when loading external files', async () => {
+  setInput('config-file', './__tests__/fixtures/no-licenses-config.yml')
+  let config = await readConfig()
+  expect(config.allow_licenses).toEqual(undefined)
+  expect(config.deny_licenses).toEqual(undefined)
+
+  setInput('config-file', './__tests__/fixtures/license-config-sample.yml')
+  config = await readConfig()
+  expect(config.fail_on_severity).toEqual('low')
+})
+
+test('it accepts an external configuration filename', async () => {
+  setInput('config-file', './__tests__/fixtures/no-licenses-config.yml')
+  const config = await readConfig()
+  expect(config.fail_on_severity).toEqual('critical')
+})
+
+test('it raises an error when given an unknown severity in an external config file', async () => {
+  setInput('config-file', './__tests__/fixtures/invalid-severity-config.yml')
+  await expect(readConfig()).rejects.toThrow()
+})
+
+test('it supports comma-separated lists', async () => {
+  setInput(
+    'config-file',
+    './__tests__/fixtures/inline-license-config-sample.yml'
+  )
+  const config = await readConfig()
+
+  expect(config.allow_licenses).toEqual(['MIT', 'GPL-2.0-only'])
+})

--- a/__tests__/external-config.test.ts
+++ b/__tests__/external-config.test.ts
@@ -31,6 +31,28 @@ function clearInputs(): void {
   })
 }
 
+const externalConfig = `fail_on_severity: 'high'
+allow_licenses: ['GPL-2.0-only']
+`
+const mockOctokit = {
+  rest: {
+    repos: {
+      getContent: jest.fn().mockReturnValue({data: externalConfig})
+    }
+  }
+}
+
+jest.mock('octokit', () => {
+  return {
+    // eslint-disable-next-line @typescript-eslint/no-extraneous-class
+    Octokit: class {
+      constructor() {
+        return mockOctokit
+      }
+    }
+  }
+})
+
 beforeAll(() => {
   jest.spyOn(Utils, 'isSPDXValid').mockReturnValue(true)
 })

--- a/__tests__/external-config.test.ts
+++ b/__tests__/external-config.test.ts
@@ -132,15 +132,8 @@ test('it reads a config file hosted in another repo', async () => {
   )
   setInput('external-repo-token', 'gh_viptoken')
 
-  setInput(
-    'config-file',
-    'future-funk/anyone-cualkiera/external-config.yml@main'
-  )
+  const config = await readConfig()
 
-  setInput('external-repo-token', 'gh_viptoken')
-
-  const config = await Config.readConfig()
-
-  expect(config.fail_on_severity).toEqual('critical')
-  expect(config.allow_licenses).toEqual(['BSD', 'GPL 2'])
+  expect(config.fail_on_severity).toEqual('high')
+  expect(config.allow_licenses).toEqual(['GPL-2.0-only'])
 })

--- a/__tests__/external-config.test.ts
+++ b/__tests__/external-config.test.ts
@@ -1,5 +1,5 @@
-import { expect, test, beforeEach } from '@jest/globals'
-import { readConfig } from '../src/config'
+import {expect, test, beforeEach} from '@jest/globals'
+import {readConfig} from '../src/config'
 import * as Utils from '../src/utils'
 
 // GitHub Action inputs come in the form of environment variables
@@ -101,4 +101,24 @@ test('it supports comma-separated lists', async () => {
   const config = await readConfig()
 
   expect(config.allow_licenses).toEqual(['MIT', 'GPL-2.0-only'])
+})
+
+test('it reads a config file hosted in another repo', async () => {
+  setInput(
+    'config-file',
+    'future-funk/anyone-cualkiera/external-config.yml@main'
+  )
+  setInput('external-repo-token', 'gh_viptoken')
+
+  setInput(
+    'config-file',
+    'future-funk/anyone-cualkiera/external-config.yml@main'
+  )
+
+  setInput('external-repo-token', 'gh_viptoken')
+
+  const config = await Config.readConfig()
+
+  expect(config.fail_on_severity).toEqual('critical')
+  expect(config.allow_licenses).toEqual(['BSD', 'GPL 2'])
 })

--- a/__tests__/fixtures/inline-license-config-sample.yml
+++ b/__tests__/fixtures/inline-license-config-sample.yml
@@ -1,1 +1,1 @@
-allow-licenses: MIT, GPL-2.0-only
+allow_licenses: MIT, GPL-2.0-only

--- a/__tests__/fixtures/inline-license-config-sample.yml
+++ b/__tests__/fixtures/inline-license-config-sample.yml
@@ -1,1 +1,1 @@
-allow_licenses: MIT, GPL-2.0-only
+allow-licenses: "MIT, GPL-2.0-only"

--- a/__tests__/fixtures/invalid-severity-config.yml
+++ b/__tests__/fixtures/invalid-severity-config.yml
@@ -1,3 +1,3 @@
-fail-on-severity: 'so many zombies'
-deny-licenses:
+fail_on_severity: 'so many zombies'
+deny_licenses:
   - MIT

--- a/__tests__/test-helpers.ts
+++ b/__tests__/test-helpers.ts
@@ -1,0 +1,28 @@
+// GitHub Action inputs come in the form of environment variables
+// with an INPUT prefix (e.g. INPUT_FAIL-ON-SEVERITY)
+export function setInput(input: string, value: string): void {
+  process.env[`INPUT_${input.toUpperCase()}`] = value
+}
+
+// We want a clean ENV before each test. We use `delete`
+// since we want `undefined` values and not empty strings.
+export function clearInputs(): void {
+  const allowedOptions = [
+    'FAIL-ON-SEVERITY',
+    'FAIL-ON-SCOPES',
+    'ALLOW-LICENSES',
+    'DENY-LICENSES',
+    'ALLOW-GHSAS',
+    'LICENSE-CHECK',
+    'VULNERABILITY-CHECK',
+    'CONFIG-FILE',
+    'BASE-REF',
+    'HEAD-REF',
+    'COMMENT-SUMMARY-IN-PR'
+  ]
+
+  // eslint-disable-next-line github/array-foreach
+  allowedOptions.forEach(option => {
+    delete process.env[`INPUT_${option.toUpperCase()}`]
+  })
+}

--- a/action.yml
+++ b/action.yml
@@ -1,3 +1,5 @@
+# Avoid using default values for options here since they will
+# end up overriding external configurations.
 name: 'Dependency Review'
 description: 'Prevent the introduction of dependencies with known vulnerabilities'
 author: 'GitHub'
@@ -9,11 +11,9 @@ inputs:
   fail-on-severity:
     description: Don't block PRs below this severity. Possible values are `low`, `moderate`, `high`, `critical`.
     required: false
-    default: 'low'
   fail-on-scopes:
     description: Dependency scopes to block PRs on. Comma-separated list. Possible values are 'unknown', 'runtime', and 'development' (e.g. "runtime, development")
     required: false
-    default: 'runtime'
   base-ref:
     description: The base git ref to be used for this check. Has a default value when the workflow event is `pull_request` or `pull_request_target`. Must be provided otherwise.
     required: false


### PR DESCRIPTION
Closes #422.

Today the Action is always returning the results as if the user had set `fail-on-severity` to `low` when using an external configuration file. This issue arises from having default values in [action.yml](https://github.com/actions/dependency-review-action/blob/main/action.yml#L12). When the Action runs it will see that no value was set for a field, and since it has a `default` it can use, it inserts it, making our code think that this was a user-specified inline config option.

Most of this PR adds tests, documentation and moves things around. The actual fix is in 9885d0c74cca15bb0f8128ee7a4018cbac4d6c32. 

PS: While working on this I realized that at some point our `README` was updated to include options with dashes in the names instead of underscores (`fail-on-severity` vs `fail_on_severity`). I would love if we supported both, but at the moment only the latter format is supported in external files. I'm highlighting this in this PR although the changes are unrelated.