### PR TITLE
Fix(docs): Correct action input name

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,7 +79,7 @@ Here are a few things you can do that will increase the likelihood of your pull 
 
 - Write tests.
 - Keep your change as focused as possible. If there are multiple changes you would like to make that are not dependent upon each other, consider submitting them as separate pull requests.
-- Write a [good commit message](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
+- Write a [good commit message](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
 
 ## Cutting a new release
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -135,7 +135,7 @@ jobs:
         uses: actions/dependency-review-action@v3
         with:
           config-file: 'github/octorepo-private/dependency-review-config.yml@main'
-          config-file-token: ${{ secrets.GITHUB_TOKEN }} # or a personal access token
+          external-repo-token: ${{ secrets.GITHUB_TOKEN }} # or a personal access token
 ```
 
 ## Getting the results of the action in the PR as a comment

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -83,7 +83,7 @@ jobs:
           config-file: './.github/dependency-review-config.yml'
 ```
 
-## Using a configuration file from a external repository
+## Using a configuration file from an external repository
 
 The following example will use a configuration file from an external public GitHub repository to configure the action.
 
@@ -110,7 +110,7 @@ jobs:
           config-file: 'github/octorepo/dependency-review-config.yml@main'
 ```
 
-## Using a configuration file from a external repository with a personal access token
+## Using a configuration file from an external repository with a personal access token
 
 The following example will use a configuration file from an external private GtiHub repository to configure the action.
 


### PR DESCRIPTION
Change the input name used for passing the personal access token to `external-repo-token`.