### PR TITLE
Updated example permissions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ on: [pull_request]
 
 permissions:
   contents: read
+  # If using a dependency submission action such as advanced-security/maven-dependency-submission-action
+  # this permission must be set to:
+  # contents: write
 
 jobs:
   dependency-review:
@@ -98,6 +101,9 @@ name: 'Dependency Review'
 on: [pull_request]
 permissions:
   contents: read
+  # If using a dependency submission action such as advanced-security/maven-dependency-submission-action
+  # this permission must be set to:
+  # contents: write
 jobs:
   dependency-review:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The permissions detailed in the readme will result in a 403 from the dependency snapshot submission API if this action is used in conjunction with e.g. `advanced-security/maven-dependency-submission-action`. It should be `contents: write` to resolve this, so I have added a couple of comments to the readme as such.