### PR TITLE
Replace pip -> pypi in PURL examples

### DIFF
--- a/__tests__/deny.test.ts
+++ b/__tests__/deny.test.ts
@@ -55,7 +55,7 @@ const pipChange: Change = {
   ecosystem: 'pip',
   name: 'package-1',
   version: '1.1.1',
-  package_url: 'pkg:pip/package-1@1.1.1',
+  package_url: 'pkg:pypi/package-1@1.1.1',
   license: 'MIT',
   source_repository_url: 'github.com/some-repo',
   scope: 'runtime',

--- a/__tests__/licenses.test.ts
+++ b/__tests__/licenses.test.ts
@@ -55,7 +55,7 @@ const pipChange: Change = {
   ecosystem: 'pip',
   name: 'package-1',
   version: '1.1.1',
-  package_url: 'pkg:pip/package-1@1.1.1',
+  package_url: 'pkg:pypi/package-1@1.1.1',
   license: 'MIT',
   source_repository_url: 'github.com/some-repo',
   scope: 'runtime',
@@ -183,7 +183,7 @@ test('it does not filter out changes that are on the exclusions list', async () 
   const changes: Changes = [pipChange, npmChange, rubyChange]
   const licensesConfig = {
     allow: ['BSD'],
-    licenseExclusions: ['pkg:pip/package-1@1.1.1', 'pkg:npm/reeuhq@1.0.2']
+    licenseExclusions: ['pkg:pypi/package-1@1.1.1', 'pkg:npm/reeuhq@1.0.2']
   }
   const invalidLicenses = await getInvalidLicenseChanges(
     changes,
@@ -199,7 +199,7 @@ test('it does not fail when the packages dont have a valid PURL', async () => {
   const changes: Changes = [emptyPurlChange, npmChange, rubyChange]
   const licensesConfig = {
     allow: ['BSD'],
-    licenseExclusions: ['pkg:pip/package-1@1.1.1', 'pkg:npm/reeuhq@1.0.2']
+    licenseExclusions: ['pkg:pypi/package-1@1.1.1', 'pkg:npm/reeuhq@1.0.2']
   }
 
   const invalidLicenses = await getInvalidLicenseChanges(
@@ -213,7 +213,10 @@ test('it does filters out changes if they are not on the exclusions list', async
   const changes: Changes = [pipChange, npmChange, rubyChange]
   const licensesConfig = {
     allow: ['BSD'],
-    licenseExclusions: ['pkg:pip/notmypackage-1@1.1.1', 'pkg:npm/alsonot@1.0.2']
+    licenseExclusions: [
+      'pkg:pypi/notmypackage-1@1.1.1',
+      'pkg:npm/alsonot@1.0.2'
+    ]
   }
   const invalidLicenses = await getInvalidLicenseChanges(
     changes,

--- a/action.yml
+++ b/action.yml
@@ -30,7 +30,7 @@ inputs:
     description: Comma-separated list of forbidden licenses (e.g. "MIT, GPL 3.0, BSD 2 Clause")
     required: false
   allow-dependencies-licenses:
-    description: Comma-separated list of dependencies in purl format (e.g. "pkg:npm/express, pkg:pip/pycrypto"). These dependencies will be permitted to use any license, no matter what license policy is enforced otherwise.
+    description: Comma-separated list of dependencies in purl format (e.g. "pkg:npm/express, pkg:pypi/pycrypto"). These dependencies will be permitted to use any license, no matter what license policy is enforced otherwise.
     required: false
   allow-ghsas:
     description: Comma-separated list of allowed GitHub Advisory IDs (e.g. "GHSA-abcd-1234-5679, GHSA-efgh-1234-5679")
@@ -48,10 +48,10 @@ inputs:
     description: Determines if the summary is posted as a comment in the PR itself. Setting this to `always` or `on-failure` requires you to give the workflow the write permissions for pull-requests
     required: false
   deny-packages:
-    description: A comma-separated list of package URLs to deny (e.g. "pkg:npm/express, pkg:pip/pycrypto")
+    description: A comma-separated list of package URLs to deny (e.g. "pkg:npm/express, pkg:pypi/pycrypto")
     required: false
   deny-groups:
-    description: A comma-separated list of package URLs for group(s)/namespace(s) to deny (e.g. "pkg:npm/express, pkg:pip/pycrypto")
+    description: A comma-separated list of package URLs for group(s)/namespace(s) to deny (e.g. "pkg:npm/express, pkg:pypi/pycrypto")
     required: false
   retry-on-snapshot-warnings:
     description: Whether to retry on snapshot warnings

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -190,7 +190,7 @@ jobs:
           fail-on-severity: critical
           deny-licenses: LGPL-2.0, BSD-2-Clause
           comment-summary-in-pr: always
-          allow-dependencies-licenses: 'pkg:npm/loadash, pkg:pip/requests'
+          allow-dependencies-licenses: 'pkg:npm/loadash, pkg:pypi/requests'
 ```
 
 If we were to use configuration file, the configuration would look like this:
@@ -202,7 +202,7 @@ allow-licenses:
   - 'BSD-2-Clause'
 allow-dependencies-licenses:
   - 'pkg:npm/loadash'
-  - 'pkg:pip/requests'
+  - 'pkg:pypi/requests'
 ```
 
 ## Only check for vulnerabilities

--- a/scripts/create_summary.ts
+++ b/scripts/create_summary.ts
@@ -26,9 +26,9 @@ const defaultConfig: ConfigurationOptions = {
   deny_groups: [],
   allow_dependencies_licenses: [
     'pkg:npm/express@4.17.1',
-    'pkg:pip/requests',
-    'pkg:pip/certifi',
-    'pkg:pip/pycrypto@2.6.1'
+    'pkg:pypi/requests',
+    'pkg:pypi/certifi',
+    'pkg:pypi/pycrypto@2.6.1'
   ],
   comment_summary_in_pr: true,
   retry_on_snapshot_warnings: false,


### PR DESCRIPTION
As mentioned in [this comment](https://github.com/actions/dependency-review-action/issues/627#issuecomment-1850310051), the references to `pip` as a possible value for a PURL are misleading. The correct value should be `pypi`.