### PR TITLE
Create stale.yaml

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -1,5 +1,8 @@
 name: Close stale PRs
 
+permissions:
+  pull-requests: write
+
 on:
   schedule:
   - cron: "00 0 * * *" # runs at 00:00 daily
@@ -11,7 +14,6 @@ jobs:
     - uses: actions/stale@v9.0.0
       name: Clean up stale PRs
       with:
-        repo-token: ${{ secrets.STALE_BOT }}
         stale-pr-message: "👋 This pull request has been marked as stale because it has been open with no activity. You can: comment on the issue or remove the stale label to hold stale off for a while, add the `Keep` label to hold stale off permanently, or do nothing. If you do nothing, this pull request will be closed eventually by the stale bot. Please see CONTRIBUTING.md for more policy details."
         stale-pr-label: "Stale"
         exempt-pr-labels: "Keep" # a "Keep" label will keep the PR from being closed as stale

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -1,0 +1,23 @@
+name: Close stale PRs
+
+on:
+  schedule:
+  - cron: "00 0 * * *" # runs at 00:00 daily
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/stale@v9.0.0
+      name: Clean up stale PRs
+      with:
+        repo-token: ${{ secrets.STALE_BOT }}
+        stale-pr-message: "👋 This pull request has been marked as stale because it has been open with no activity. You can: comment on the issue or remove the stale label to hold stale off for a while, add the `Keep` label to hold stale off permanently, or do nothing. If you do nothing, this pull request will be closed eventually by the stale bot. Please see CONTRIBUTING.md for more policy details."
+        stale-pr-label: "Stale"
+        exempt-pr-labels: "Keep" # a "Keep" label will keep the PR from being closed as stale
+        days-before-pr-stale: 180 # when the PR is considered stale
+        days-before-pr-close: 15 # when the PR is closed by the bot, 
+        days-before-issue-stale: -1 # prevents issues from being tagged by the bot
+        days-before-issue-close: -1 # prevents issues from being closed by the bot
+        exempt-assignees: 'advanced-security-dependency-graph'
+        ascending: true


### PR DESCRIPTION
Creating a stalebot workflow that will check every day for stale PRs older than 180 days, then close any that were labeled 'stale' after another 15 days.

It exempts any PRs assigned to the dependency graph dev team.

This will also need a PAT created, and stored as a repo secret with the name ```STALE_BOT```