### PR TITLE
Use manual codeql config

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,45 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  schedule:
+    - cron: '21 0 * * 4'
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: 'ubuntu-latest'
+    timeout-minutes: 360
+    permissions:
+      # required for all workflows
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'javascript-typescript' ]
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v3
+      with:
+        languages: ${{ matrix.language }}
+        # If you wish to specify custom queries, you can do so here or in a config file.
+        # By default, queries listed here will override any specified in a config file.
+        # Prefix the list here with "+" to use these queries and those in the config file.
+
+        # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
+        # queries: security-extended,security-and-quality
+        paths-ignore: dist/index.js,dist/sourcemap-register.js
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v3
+      with:
+        category: "/language:${{matrix.language}}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -37,7 +37,10 @@ jobs:
 
         # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
         # queries: security-extended,security-and-quality
-        paths-ignore: dist/index.js,dist/sourcemap-register.js
+        config: |
+          paths-ignore: 
+            - dist/index.js
+            - dist/sourcemap-register.js
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
We now have CodeQL running on this repository, but it's reporting failures in the generated JavaScript. AFAICT, these alerts are not based on any TypeScript code that we can actually change, so I think the right move is to exclude the generated JavaScript files from Code Scanning and rely on the TypeScript coverage to generate alerts that are actually actionable.

I based this config on the auto-generated one, but I removed a few things like Swift and Ruby matrix items and MacOS builds.

Ultimately the whole point of this is really the line `paths-ignore: dist/index.js,dist/sourcemap-register.js`.