### PR TITLE
Remove Ruby from devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,8 +2,5 @@
   "name": "Dependency Review Action",
   "image": "mcr.microsoft.com/devcontainers/typescript-node:18",
   "postCreateCommand": "npm install",
-  "remoteUser": "node",
-  "features": {
-    "ghcr.io/devcontainers/features/ruby:1": {}
-  }
+  "remoteUser": "node"
 }


### PR DESCRIPTION
Our devcontainer configuration currently includes Ruby, which slows down Codespace creation and isn't necessary. This PR removes that from the configuration