### PR TITLE
Revert default values in action.yml to fix external configs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,13 @@
-# Avoid using default values for options here since they will
-# end up overriding external configurations.
+# IMPORTANT
+#
+# Avoid setting default values for configuration options in
+# this file, they will overwrite external configurations.
+#
+# If you are trying to find out the default value for a config
+# option please take a look at the README or src/schemas.ts.
+#
+# If you are adding an option, make sure the Zod definition
+# contains a default value.
 name: 'Dependency Review'
 description: 'Prevent the introduction of dependencies with known vulnerabilities'
 author: 'GitHub'
@@ -56,23 +64,18 @@ inputs:
   retry-on-snapshot-warnings:
     description: Whether to retry on snapshot warnings
     required: false
-    default: false
   retry-on-snapshot-warnings-timeout:
     description: Number of seconds to wait before stopping snapshot retries.
     required: false
-    default: 120
   warn-only:
     description: When set to `true` this action will always complete with success, overriding the `fail-on-severity` parameter.
     required: false
-    default: false
   show-openssf-scorecard:
     description: Show a summary of the OpenSSF Scorecard scores.
     required: false
-    default: true
   warn-on-openssf-scorecard-level:
     description: Numeric threshold for the OpenSSF Scorecard score. If the score is below this threshold, the action will warn you.
     required: false
-    default: 3
 outputs:
   comment-content:
     description: Prepared dependency report comment


### PR DESCRIPTION
Closes #706.

### Context

Dependency Review Action supports configuration by three different methods:

* Inline configuration (writing your config options in your YML)
* In-repo config file (your config lives in a YML file inside your repo)
* External config (your config file lives in a repo that you have access to)

In order to handle these three cases, we don't allow adding `default` fields to the project's `action.yml`.

### Description

A few of the recently introduced options have modified the default values in `action.yml`, ignoring the comment at the top, and breaking integrations with external configuration files. 

This PR rewrittes the comment at the top (making it bigger should call more attention to it), and I removed the `default` field from the config options that had it [^0].

A proper solution given more time would be to introduce a linter that checks for non-token `default:` entries in `action.yml` to block merging the changes. Issue created here: https://github.com/actions/dependency-review-action/issues/723

[^0]: The repo token is an exception to this, since we need to have it set by the time the Zod parsers are loaded.

