### PR TITLE
PR with suggestions - [Improvement]: Help streamline / simplify dependency review action README 

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ You can install the action on any public repository, or any organization-owned p
 
 You can install the action on repositories on GitHub Enterprise Server. 
 
-1. Ensure [GitHub Advanced Security](https://docs.github.com/en/enterprise-server@3.12/admin/code-security/managing-github-advanced-security-for-your-enterprise/enabling-github-advanced-security-for-your-enterprise) and [GitHub Connect](https://docs.github.com/en/enterprise-server@3.12/admin/github-actions/managing-access-to-actions-from-githubcom/enabling-automatic-access-to-githubcom-actions-using-github-connect) are enabled for the enterprise.
+1. Ensure [GitHub Advanced Security](https://docs.github.com/en/enterprise-server@latest/admin/code-security/managing-github-advanced-security-for-your-enterprise/enabling-github-advanced-security-for-your-enterprise) and [GitHub Connect](https://docs.github.com/en/enterprise-server@latest/admin/github-actions/managing-access-to-actions-from-githubcom/enabling-automatic-access-to-githubcom-actions-using-github-connect) are enabled for the enterprise.
 2. Ensure you have installed the [dependency-review-action](https://github.com/actions/dependency-review-action) on the server.
 3. Add a new YAML workflow to your `.github/workflows` folder:
 

--- a/README.md
+++ b/README.md
@@ -238,7 +238,8 @@ Dependency review action can create [outputs](https://docs.github.com/en/actions
 >   echo "$VULNERABLE_CHANGES" | jq
 > ```
 >
-> instead of direct `echo '${{ steps.review.outputs.vulnerable-changes }}'`. See [examples](docs/examples.md) for more.
+> instead of direct `echo '${{ steps.review.outputs.vulnerable-changes }}'`. 
+> See [examples](docs/examples.md) for more.
 
 ## Getting help
 

--- a/README.md
+++ b/README.md
@@ -227,9 +227,8 @@ Dependency review action can create [outputs](https://docs.github.com/en/actions
   - `denied-changes` holds information about denied dependency changes in a JSON format.
 
 > [!NOTE]
-> Action outputs are unicode strings [with a 1MB size limit](https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#outputs-for-docker-container-and-javascript-actions).
-
-> [!NOTE]
+> Action outputs are unicode strings [with a 1MB size limit](https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#outputs-for-docker-container-and-javascript-actions).   
+>
 > If you use these outputs in a run-step, you must store the output data in an environment variable instead of using the output directly. Using an output directly might break shell scripts. For example:
 >
 > ```yaml

--- a/README.md
+++ b/README.md
@@ -23,13 +23,16 @@ The action is available for:
 When the action runs, you can see the results on:  
 
 - The **job logs** page. 
-  - Go to the **Actions** tab for the repository and select the relevant workflow run. Then under "Jobs", click **dependency review**.
+  1. Go to the **Actions** tab for the repository and select the relevant workflow run. 
+  1. Then under "Jobs", click **dependency review**.
 
-   <img width="850" alt="GitHub workflow run log showing Dependency Review job output" src="https://user-images.githubusercontent.com/2161/161042286-b22d7dd3-13cb-458d-8744-ce70ed9bf562.png">
+      <img width="850" alt="GitHub workflow run log showing Dependency Review job output" src="https://user-images.githubusercontent.com/2161/161042286-b22d7dd3-13cb-458d-8744-ce70ed9bf562.png">
 
 - The **job summary** page.
-  - Go to the **Actions** tab for the repository and select the relevant workflow run. Click **Summary**, then scroll to "dependency-review summary". 
-  <img width="850" alt="GitHub job summary showing Dependency Review output" src="https://github.com/actions/dependency-review-action/assets/2161/42fbed1d-64a7-42bf-9b05-c416bc67493f">
+  1. Go to the **Actions** tab for the repository and select the relevant workflow run. 
+  1. Click **Summary**, then scroll to "dependency-review summary". 
+     
+     <img width="850" alt="GitHub job summary showing Dependency Review output" src="https://github.com/actions/dependency-review-action/assets/2161/42fbed1d-64a7-42bf-9b05-c416bc67493f">
 
 ## Installation
 
@@ -92,7 +95,7 @@ You can install the action on repositories on GitHub Enterprise Server.
 
 ### Configuration options
 
-There are various configuration options you can use to customize the dependency review action.
+There are various configuration options you can use to specify settings for the dependency review action.
 
 All configuration options are optional. 
 
@@ -204,9 +207,10 @@ You can use an external configuration file to specify settings for this action. 
 > For external configuration files, the option names use underscores instead of dashes.
 > Example: `fail_on_severity`
 
-#### Further example configurations
+#### Further information
 
-For more examples of how to use this action and its configuration options, see the [examples](docs/examples.md) page.
+- For more examples of how to use this action and its configuration options, see the [examples](docs/examples.md) page.
+- For general information about dependency review on GitHub, see "[About dependency review](https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/about-dependency-review)" in the GitHub Docs documentation.
 
 ## Using dependency review action to block a pull request from being merged
 
@@ -214,7 +218,7 @@ You can configure your repository to block a pull request from being merged if t
 
 ## Outputs
 
-[Insert overview line here - what does output refer to? What / how it is used?]
+[TODO: Insert overview line here - what does output refer to? What / how it is used?]
 
 - `comment-content` is generated with the same content as would be present in a Dependency Review Action comment.
 - `dependency-changes` holds all dependency changes in a JSON format. The following outputs are subsets of `dependency-changes` filtered based on the configuration:

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ All configuration options are optional.
 > - \* Not supported for use with GitHub Enterprise Server. (Checking for licenses is not supported on GitHub Enterprise Server because the API does not return license information.)
 > - \+ When `warn-only` is set to `true`, all vulnerabilities, independently of the severity, will be reported as warnings and the action will not fail.
 > - The `allow-licenses` and `deny-licenses` options are mutually exclusive; an error will be raised if you provide both.
-> - We don't have license information for all of your dependents. If we can't detect the license for a dependency **we will inform you, but the action won't fail**.
+> - If we can't detect the license for a dependency **we will inform you, but the action won't fail**.
 
 ### Configuration methods
 

--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ You can configure your repository to block a pull request from being merged if t
 
 ## Outputs
 
-[TODO: Insert overview line here - what does output refer to? What / how it is used?]
+Dependency review action can create [outputs](https://docs.github.com/en/actions/using-jobs/defining-outputs-for-jobs), so that data from its execution can be used by other jobs in a workflow.
 
 - `comment-content` is generated with the same content as would be present in a Dependency Review Action comment.
 - `dependency-changes` holds all dependency changes in a JSON format. The following outputs are subsets of `dependency-changes` filtered based on the configuration:

--- a/README.md
+++ b/README.md
@@ -1,17 +1,32 @@
 # dependency-review-action
 
-This action scans your pull requests for dependency changes, and will
-raise an error if any vulnerabilities or invalid licenses are being introduced. The action is supported by an [API endpoint](https://docs.github.com/rest/dependency-graph/dependency-review) that diffs the dependencies between any two revisions on your default branch.
+- [Overview](#overview)
+- [Installation](#installation)
+- [Configuration](#configuration)
 
-The action is available for all public repositories, as well as private repositories that have GitHub Advanced Security licensed.
+- [Outputs](#outputs)
+- [Getting help](#getting-help)
+- [Contributing](#contributing)
+- [License](#license)
 
-You can see the results on the job logs:
+## Overview
 
-<img width="850" alt="GitHub workflow run log showing Dependency Review job output" src="https://user-images.githubusercontent.com/2161/161042286-b22d7dd3-13cb-458d-8744-ce70ed9bf562.png">
+The dependency review action scans your pull requests for dependency changes, and will raise an error if any vulnerabilities or invalid licenses are being introduced. 
+The action is supported by an [API endpoint](https://docs.github.com/en/rest/dependency-graph/dependency-review?apiVersion=2022-11-28) that diffs the dependencies between any two revisions on your default branch.
 
-or on the job summary:
+When the action runs, you can see the results on:
 
-<img width="850" alt="GitHub job summary showing Dependency Review output" src="https://github.com/actions/dependency-review-action/assets/2161/42fbed1d-64a7-42bf-9b05-c416bc67493f">
+- The **job logs**, found ....
+
+  <img width="850" alt="GitHub workflow run log showing Dependency Review job output" src="https://user-images.githubusercontent.com/2161/161042286-b22d7dd3-13cb-458d-8744-ce70ed9bf562.png">
+
+- The **job summary**, found ....
+
+  <img width="850" alt="GitHub job summary showing Dependency Review output" src="https://github.com/actions/dependency-review-action/assets/2161/42fbed1d-64a7-42bf-9b05-c416bc67493f">
+
+The action is available for: 
+- Public repositories
+- Private repositories with a [GitHub Advanced Security](https://docs.github.com/en/enterprise-cloud@latest/get-started/learning-about-github/about-github-advanced-security) license.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -223,8 +223,8 @@ Dependency review action can create [outputs](https://docs.github.com/en/actions
 - `comment-content` is generated with the same content as would be present in a Dependency Review Action comment.
 - `dependency-changes` holds all dependency changes in a JSON format. The following outputs are subsets of `dependency-changes` filtered based on the configuration:
   - `vulnerable-changes` holds information about dependency changes with vulnerable dependencies in a JSON format.
-- `invalid-license-changes` holds information about invalid or non-compliant license dependency changes in a JSON format.
-- `denied-changes` holds information about denied dependency changes in a JSON format.
+  - `invalid-license-changes` holds information about invalid or non-compliant license dependency changes in a JSON format.
+  - `denied-changes` holds information about denied dependency changes in a JSON format.
 
 > [!NOTE]
 > Action outputs are unicode strings [with a 1MB size limit](https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#outputs-for-docker-container-and-javascript-actions).

--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ Dependency review action can create [outputs](https://docs.github.com/en/actions
 
 - `comment-content` is generated with the same content as would be present in a Dependency Review Action comment.
 - `dependency-changes` holds all dependency changes in a JSON format. The following outputs are subsets of `dependency-changes` filtered based on the configuration:
-- `vulnerable-changes` holds information about dependency changes with vulnerable dependencies in a JSON format.
+  - `vulnerable-changes` holds information about dependency changes with vulnerable dependencies in a JSON format.
 - `invalid-license-changes` holds information about invalid or non-compliant license dependency changes in a JSON format.
 - `denied-changes` holds information about denied dependency changes in a JSON format.
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@
 The dependency review action scans your pull requests for dependency changes, and will raise an error if any vulnerabilities or invalid licenses are being introduced. 
 The action is supported by an [API endpoint](https://docs.github.com/en/rest/dependency-graph/dependency-review?apiVersion=2022-11-28) that diffs the dependencies between any two revisions on your default branch.
 
+The action is available for: 
+- Public repositories
+- Private repositories with a [GitHub Advanced Security](https://docs.github.com/en/enterprise-cloud@latest/get-started/learning-about-github/about-github-advanced-security) license.
+
 When the action runs, you can see the results on:
 
 - The **job logs**, found ....
@@ -24,58 +28,60 @@ When the action runs, you can see the results on:
 
   <img width="850" alt="GitHub job summary showing Dependency Review output" src="https://github.com/actions/dependency-review-action/assets/2161/42fbed1d-64a7-42bf-9b05-c416bc67493f">
 
-The action is available for: 
-- Public repositories
-- Private repositories with a [GitHub Advanced Security](https://docs.github.com/en/enterprise-cloud@latest/get-started/learning-about-github/about-github-advanced-security) license.
 
 ## Installation
 
-**Please keep in mind that you need a [GitHub Advanced Security](https://docs.github.com/enterprise-cloud@latest/get-started/learning-about-github/about-github-advanced-security) license if you're running this action on private repositories.**
+- [Installation (standard)](#installation)
+- [Installation (GitHub Enterprise Server)](#installation-github-enterprise-server)
+
+#### Installation (standard)
+
+You can install the action on any public repository, or any organization-owned private repository, provided the organization has a GitHub Advanced Security license. 
 
 1. Add a new YAML workflow to your `.github/workflows` folder:
 
-```yaml
-name: 'Dependency Review'
-on: [pull_request]
+   ```yaml
+   name: 'Dependency Review'
+   on: [pull_request]
 
-permissions:
-  contents: read
+   permissions:
+     contents: read
 
-jobs:
-  dependency-review:
-    runs-on: ubuntu-latest
-    steps:
-      - name: 'Checkout Repository'
-        uses: actions/checkout@v4
-      - name: 'Dependency Review'
-        uses: actions/dependency-review-action@v4
-```
+   jobs:
+     dependency-review:
+       runs-on: ubuntu-latest
+       steps:
+         - name: 'Checkout Repository'
+           uses: actions/checkout@v4
+         - name: 'Dependency Review'
+           uses: actions/dependency-review-action@v4
+   ```
 
-### GitHub Enterprise Server
+#### Installation (GitHub Enterprise Server)
 
-Make sure
-[GitHub Advanced
-Security](https://docs.github.com/enterprise-server@3.8/admin/code-security/managing-github-advanced-security-for-your-enterprise/enabling-github-advanced-security-for-your-enterprise)
-and [GitHub
-Connect](https://docs.github.com/enterprise-server@3.8/admin/github-actions/managing-access-to-actions-from-githubcom/enabling-automatic-access-to-githubcom-actions-using-github-connect)
-are enabled, and that you have installed the [dependency-review-action](https://github.com/actions/dependency-review-action) on the server.
+You can install the action on repositories on GitHub Enterprise Server. 
 
-You can use the same workflow as above, replacing the `runs-on` value
-with the label of any of your runners (the default label
-is `self-hosted`):
+1. Ensure [GitHub Advanced Security](https://docs.github.com/en/enterprise-server@3.12/admin/code-security/managing-github-advanced-security-for-your-enterprise/enabling-github-advanced-security-for-your-enterprise) and [GitHub Connect](https://docs.github.com/en/enterprise-server@3.12/admin/github-actions/managing-access-to-actions-from-githubcom/enabling-automatic-access-to-githubcom-actions-using-github-connect) are enabled for the enterprise.
+2. Ensure you have installed the [dependency-review-action](https://github.com/actions/dependency-review-action) on the server.
+3. Add a new YAML workflow to your `.github/workflows` folder:
 
-```yaml
-# ...
+   ``` yaml
+   name: 'Dependency Review'
+   on: [pull_request]
 
-jobs:
-  dependency-review:
-    runs-on: self-hosted
-    steps:
-      - name: 'Checkout Repository'
-        uses: actions/checkout@v4
-      - name: 'Dependency Review'
-        uses: actions/dependency-review-action@v4
-```
+   permissions:
+     contents: read
+
+   jobs:
+     dependency-review:
+       runs-on: self-hosted
+       steps:
+         - name: 'Checkout Repository'
+           uses: actions/checkout@v4
+         - name: 'Dependency Review'
+           uses: actions/dependency-review-action@v4
+   ```
+5. In the workflow file, replace the `runs-on` value with the label of any of your runners. (The default value is `self-hosted`.)
 
 ## Configuration options
 

--- a/README.md
+++ b/README.md
@@ -18,16 +18,18 @@ The action is available for:
 - Public repositories
 - Private repositories with a [GitHub Advanced Security](https://docs.github.com/en/enterprise-cloud@latest/get-started/learning-about-github/about-github-advanced-security) license.
 
-When the action runs, you can see the results on:
+### Viewing the results
 
-- The **job logs**, found ....
+When the action runs, you can see the results on:  
 
-  <img width="850" alt="GitHub workflow run log showing Dependency Review job output" src="https://user-images.githubusercontent.com/2161/161042286-b22d7dd3-13cb-458d-8744-ce70ed9bf562.png">
+- The **job logs** page. 
+  - Go to the **Actions** tab for the repository and select the relevant workflow run. Then under "Jobs", click **dependency review**.
 
-- The **job summary**, found ....
+   <img width="850" alt="GitHub workflow run log showing Dependency Review job output" src="https://user-images.githubusercontent.com/2161/161042286-b22d7dd3-13cb-458d-8744-ce70ed9bf562.png">
 
+- The **job summary** page.
+  - Go to the **Actions** tab for the repository and select the relevant workflow run. Click **Summary**, then scroll to "dependency-review summary". 
   <img width="850" alt="GitHub job summary showing Dependency Review output" src="https://github.com/actions/dependency-review-action/assets/2161/42fbed1d-64a7-42bf-9b05-c416bc67493f">
-
 
 ## Installation
 


### PR DESCRIPTION
Linked to: "[[Improvement]: Help streamline / simplify dependency review action README#14071](https://github.com/github/docs-content/issues/14071)"

Suggestions made: 
- Added TOC for easier navigation
- Re-worked intro into an "Overview" section and a "Viewing your results" sub-section.
   - Added some info on where/how to find job logs / job summary. (Needs checking for accuracy)
- Re-structured content into new heading and sub-headings. 
  - Re-structured "Installation" and added mini TOC ("Installation (Standard)", "Installation (GitHub Enterprise Server)"
  - Re-configured "Configuration options" section into "Configuration" and added mini TOC to two sub-sections: "Configuration options" and "Configuration methods".
  - Merged existing table notes and considerations for configuration options into one "Notes" sections after the large table. 
  - Split "configuration methods" into two sub-sub-sections ("Option 1: Using inline configuration..." and "Option 2: Using an external configuration file")
  - Re-worked same content for clarity - into set procedural steps. 
- Kept final sections as they are (Outputs, Blocking pull requests [re-named section heading to something more explanative], Getting help, Contributing, Licenses)
- Updated GHES links to "enterprise-server@**latest**" (e.g.) `https://docs.github.com/en/enterprise-server@latest/admin/code-security/managing-github-advanced-security-for-your-enterprise/enabling-github-advanced-security-for-your-enterprise` (The existing links link out to GHES 3.8 (soon to be deprecated), so this will keep the links up to date.) 
- Added a link to docs for general info on dependency review (suggestion)

To do:
- For "Outputs" - what is outputs used for? I would like to add an intro line here, but I'm not sure what to put. Could you advise? 
