### PR TITLE
Updates to the contribution guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,14 +39,14 @@ The action then evaluates the differences between the pushes based on the the ru
 
 ### Local Development
 
-It is required to have at least [Node 18](https://nodejs.org/en/) installed.
+Before you begin, you need to have [Node.js](https://nodejs.org/en/) installed, minimum version 18.
 
 #### Bootstrapping the project
 
-0. Clone the repository: `git clone https://github.com/actions/dependency-review-action.git`
-1. Change to the working directory, and configure and install the dependencies: `cd dependency-review-action`, then `npm install`
-2. Make sure the tests pass on your machine: `npm run test`
-
+0. [Fork][fork] and clone the repository
+1. Change to the working directory: `cd dependency-review-action`
+2. Install the dependencies: `npm install`
+3. Make sure the tests pass on your machine: `npm run test`
 
 #### Manually testing for vulnerabilities
 
@@ -83,7 +83,6 @@ npm run test
 
 _Note_: We don't a very comprehensive test suite, so any contributions to the existing tests are welcome!
 
-
 ### Submitting a pull request
 
 1. Create a new branch: `git checkout -b my-branch-name`
@@ -101,6 +100,8 @@ Here are a few things you can do that will increase the likelihood of your pull 
 - Please be responsive to any questions and feedback that you get from a maintainer of the repo!
 
 ## Cutting a new release
+
+<details>
 
 _Note: these instructions are for maintainers_
 
@@ -136,10 +137,11 @@ To do this just checkout `main`, force-create a new annotated tag, and push it:
 git tag -fa v4 -m "Updating v4 to 4.0.1"
 git push origin v4 --force
 ```
-
+</details>
 
 
 ## Resources
 
+- [Creating JavaScript GitHub actions](https://docs.github.com/en/actions/creating-actions/creating-a-javascript-action)
 - [How to Contribute to Open Source](https://opensource.guide/how-to-contribute/)
 - [Using Pull Requests](https://help.github.com/articles/about-pull-requests/)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,7 +64,7 @@ $ GITHUB_TOKEN=<token> ./scripts/scan_pr <pr_url>
 Like this:
 
 ```sh
-$ GITHUB_TOKEN=my-secret-token ./scripts/scan_pr https://github.com/actions/dependency-review-action/pull/3
+$ GITHUB_TOKEN=<token> ./scripts/scan_pr https://github.com/actions/dependency-review-action/pull/3
 ```
 
 [Configuration options](README.md#configuration-options) can be set by

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ If you've encountered a problem, please let us know by [submitting an issue](htt
 
 If you've got an idea for a new feature, please submit as [an issue](https://github.com/actions/dependency-review-action/issues/new) so that the community can see it, and we can discuss it there. We may not be able to respond to every single issue, but will make a best effort!
 
-If you'd like to make a contribution yourself, we ask that before significant effort is put into code changes, that we have agreement that the change aligns with our strategy for the action. Since GitHub is ultimately the primary maintainer of this action, we want to make sure that contributions are high quality, and that they maintain consistency with the rest of the action's behavior.
+If you'd like to make a contribution yourself, we ask that before significant effort is put into code changes, that we have agreement that the change aligns with our strategy for the action. Since this is a verified Action owned by GitHub we want to make sure that contributions are high quality, and that they maintain consistency with the rest of the action's behavior.
 
 1. Create an [issue discussing the idea](https://github.com/actions/dependency-review-action/issues/new), so that we can discuss it there.
 2. If we agree to incorporate the idea into the action, please write-up a high level summary of the approach that you plan to take so we can review

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ If you've got an idea for a new feature, please submit as [an issue](https://git
 If you'd like to make a contribution yourself, we ask that before significant effort is put into code changes, that we have agreement that the change aligns with our strategy for the action. Since GitHub is ultimately the primary maintainer of this action, we want to make sure that contributions are high quality, and that they maintain consistency with the rest of the action's behavior.
 
 1. Create an [issue discussing the idea](https://github.com/actions/dependency-review-action/issues/new), so that we can discuss it there.
-2. If we agree to incorporate the idea into the action, please write-up a high level summary of the approach that you plan to take so
+2. If we agree to incorporate the idea into the action, please write-up a high level summary of the approach that you plan to take so we can review
 
 ## Stalebot
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,41 +4,52 @@
 [pr]: https://github.com/actions/dependency-review-action/compare
 [code-of-conduct]: CODE_OF_CONDUCT.md
 
-Hi there! We're thrilled that you'd like to contribute to this project. Your help is essential for keeping it great.
+Hi there! We're thrilled that you'd like to contribute to this project.
 
-Contributions to this project are
-[released](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license)
-to the public under the [project's open source license](LICENSE).
+Contributions to this project are [released](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) to the public under the [project's open source license](LICENSE).
 
-Please note that this project is released with a [Contributor Code of
-Conduct][code-of-conduct]. By participating in this project you agree
-to abide by its terms.
+Please note that this project is released with a [Contributor Code of Conduct][code-of-conduct]. By participating in this project you agree to abide by its terms.
 
-### How it works
+## Bug reports and other issues
 
-This Action makes an authenticated query to the Dependency Graph Diff
-API endpoint (`GET /repos/{owner}/{repo}/dependency-graph/compare/{basehead}`)
-to find out the set of added and removed dependencies for each manifest.
+If you've encountered a problem, please let us know by [submitting an issue](https://github.com/actions/dependency-review-action/issues/new)!
 
-### Bootstrapping the project
+## Enhancements and feature requests
 
-```
-git clone https://github.com/actions/dependency-review-action.git
-cd dependency-review-action
-npm install
-```
+If you've got an idea for a new feature, please submit as [an issue](https://github.com/actions/dependency-review-action/issues/new) so that the community can see it, and we can discuss it there. We may not be able to respond to every single issue, but will make a best effort!
 
-### Running the tests
+If you'd like to make a contribution yourself, we ask that before significant effort is put into code changes, that we have agreement that the change aligns with our strategy for the action. Since GitHub is ultimately the primary maintainer of this action, we want to make sure that contributions are high quality, and that they maintain consistency with the rest of the action's behavior.
 
-```
-npm run test
-```
+1. Create an [issue discussing the idea](https://github.com/actions/dependency-review-action/issues/new), so that we can discuss it there.
+2. If we agree to incorporate the idea into the action, please write-up a high level summary of the approach that you plan to take so
 
-_Note_: We don't have any useful tests yet, contributions are welcome!
+## Stalebot
 
-## Local Development
+We have begun using a [Stalebot action](https://github.com/actions/stale) to help keep the Issues and Pull requests backlogs tidy. You can see the configuration [here](.github/workflows/stalebot.yml). If you'd like to keep an issue open after getting a stalebot warning, simply comment on it and it'll reset the clock.
 
-It is recommended to have atleast [Node 18](https://nodejs.org/en/) installed.
+## Development lifecycle
+
+Ready to contribute to `dependency-review-action`?  Here is some information to help you get started.
+
+### High level overview of the action
+
+This action makes an authenticated query to the [Dependency Review API](https://docs.github.com/en/rest/dependency-graph/dependency-review) endpoint (`GET /repos/{owner}/{repo}/dependency-graph/compare/{basehead}`) to find out the set of added and removed dependencies for each manifest.
+
+The action then evaluates the differences between the pushes based on the the rules defined in the action configuration, and summarizes the differences and any violations of the rules you have defined as a comment in the pull request that triggered it and the action outputs.
+
+### Local Development
+
+It is required to have at least [Node 18](https://nodejs.org/en/) installed.
+
+#### Bootstrapping the project
+
+0. Clone the repository: `git clone https://github.com/actions/dependency-review-action.git`
+1. Change to the working directory, and configure and install the dependencies: `cd dependency-review-action`, then `npm install`
+2. Make sure the tests pass on your machine: `npm run test`
+
+
+#### Manually testing for vulnerabilities
+
 We have a script to scan a given PR for vulnerabilities, this will
 help you test your local changes. Make sure to [grab a Personal Access Token (PAT)](https://github.com/settings/tokens) before proceeding (you'll need `repo` permissions for private repos):
 
@@ -64,16 +75,21 @@ passing an external YAML [configuration file](README.md#configuration-file) to t
 $ GITHUB_TOKEN=<token> ./scripts/scan_pr --config-file my_custom_config.yml <pr_url>
 ```
 
-## Submitting a pull request
+#### Running unit tests
 
-0. [Fork][fork] and clone the repository
-1. Configure and install the dependencies: `npm install`
-2. Make sure the tests pass on your machine: `npm run test`
-3. Create a new branch: `git checkout -b my-branch-name`
-4. Make your change, add tests, and make sure the tests still pass
-5. Make sure to build and package before pushing: `npm run build && npm run package`
-6. Push to your fork and [submit a pull request][pr]
-7. Pat your self on the back and wait for your pull request to be reviewed and merged.
+```
+npm run test
+```
+
+_Note_: We don't a very comprehensive test suite, so any contributions to the existing tests are welcome!
+
+
+### Submitting a pull request
+
+1. Create a new branch: `git checkout -b my-branch-name`
+2. Make your change, add tests, and make sure the tests still pass
+3. Make sure to build and package before pushing: `npm run build && npm run package`
+4. Push to your fork and [submit a pull request][pr]
 
 Here are a few things you can do that will increase the likelihood of your pull request being accepted:
 
@@ -82,8 +98,11 @@ Here are a few things you can do that will increase the likelihood of your pull 
 - Write a [good commit message](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
 - Add examples of the usage to [examples.md](docs/examples.md)
 - Link to a sample PR in a custom repository running your version of the Action.
+- Please be responsive to any questions and feedback that you get from a maintainer of the repo!
 
 ## Cutting a new release
+
+_Note: these instructions are for maintainers_
 
 1. Update the version number in [package.json](https://github.com/actions/dependency-review-action/blob/main/package.json) and run `npm i` to update the lockfile.
 1. Go to [Draft a new
@@ -118,12 +137,9 @@ git tag -fa v4 -m "Updating v4 to 4.0.1"
 git push origin v4 --force
 ```
 
-## Stalebot
 
-We have begun using a [Stalebot action](https://github.com/actions/stale) to help keep the Issues and Pull requests backlogs tidy. You can see the configuration [here](.github/workflows/stalebot.yml). If you'd like to keep an issue open after getting a stalebot warning, simply comment on it and it'll reset the clock.
 
 ## Resources
 
 - [How to Contribute to Open Source](https://opensource.guide/how-to-contribute/)
 - [Using Pull Requests](https://help.github.com/articles/about-pull-requests/)
-- [GitHub Help](https://help.github.com)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,3 +1,3 @@
-If you discover a security issue in this repo, please submit it through the [GitHub Security Bug Bounty](https://hackerone.com/github)
+If you discover a security issue in this repo, please submit it through the [GitHub Security Bug Bounty](https://bounty.github.com/)
 
 Thanks for helping make GitHub Actions safe for everyone.


### PR DESCRIPTION
Reorganizing the contribution guidelines to make them more readable and adding more information about the development lifecycle. Also updating the link to submit a security issue in the security guidelines.

todo: when [issue templates are merged](https://github.com/actions/dependency-review-action/pull/777), update the link to the issue template in the contribution guidelines rather than use the default issue creation link.