### PR TITLE
To not print OpenSSF Scorecard section if no dependencies scanned

### DIFF
--- a/src/summary.ts
+++ b/src/summary.ts
@@ -291,7 +291,9 @@ export function addScannedFiles(changes: Changes): void {
     }
   }
 
-  core.summary.addHeading('Scanned Files', 2).addList(manifests)
+  core.summary
+    .addHeading('Scanned Files', 2)
+    .addList(manifests.length === 0 ? ['None'] : manifests)
 }
 
 function snapshotWarningRecommendation(
@@ -316,6 +318,9 @@ export function addScorecardToSummary(
   scorecard: Scorecard,
   config: ConfigurationOptions
 ): void {
+  if (scorecard.dependencies.length === 0) {
+    return
+  }
   core.summary.addHeading('OpenSSF Scorecard', 2)
   if (scorecard.dependencies.length > 10) {
     core.summary.addRaw(`<details><summary>Scorecard details</summary>`, true)

--- a/src/summary.ts
+++ b/src/summary.ts
@@ -291,9 +291,12 @@ export function addScannedFiles(changes: Changes): void {
     }
   }
 
-  core.summary
-    .addHeading('Scanned Files', 2)
-    .addList(manifests.length === 0 ? ['None'] : manifests)
+  const summary = core.summary.addHeading('Scanned Files', 2)
+  if (manifests.length === 0) {
+    summary.addRaw('None')
+  } else {
+    summary.addList(manifests)
+  }
 }
 
 function snapshotWarningRecommendation(


### PR DESCRIPTION
- **OpenSSF Scorecard** section: to not print it if no dependencies scanned.
- **Scanned Files** section: print `None` if no dependencies scanned. I thought it would be better for the user to see the statement that no files were scanned explicitly.

---

Fixes #863 