### PR TITLE
Handle any SPDX dependencies as a priority Dependabot PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,5 +15,11 @@ updates:
     groups:
       minor-updates:
         update-types:
-        - "minor"
-        - "patch"
+          - 'minor'
+          - 'patch'
+        exclude-patterns:
+          - '*spdx*'
+      # Pull out any updates to spdx definitions and parsing as a priority PR
+      spdx-licenses:
+        patterns:
+          - '*spdx*'


### PR DESCRIPTION
This updates our Dependabot configuration to exclude our three SPDX-related dependencies from the `minor-updates` group and create a separate PR for them.

The rationale is that staying on top of downstream SPDX changes is a mission-critical aspect of this action so we should avoid them being buried in lower-priority update PRs we may not cut a release for.