### PR TITLE
Update Node.js version to 24 and related dependencies

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -23,10 +23,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set Node.js 20.x
+      - name: Set Node.js 24.x
         uses: actions/setup-node@v4
         with:
-          node-version: 20.x
+          node-version: 24.x
           cache: npm
 
       - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
       - name: Install dependencies
         run: npm ci --ignore-scripts
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
       - name: Install dependencies
         run: npm ci --ignore-scripts

--- a/action.yml
+++ b/action.yml
@@ -89,5 +89,5 @@ outputs:
     description: Denied dependency changes (JSON)
 
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'

--- a/action.yml
+++ b/action.yml
@@ -89,5 +89,5 @@ outputs:
     description: Denied dependency changes (JSON)
 
 runs:
-  using: 'node24'
+  using: 'node24' 
   main: 'dist/index.js'

--- a/action.yml
+++ b/action.yml
@@ -89,5 +89,5 @@ outputs:
     description: Denied dependency changes (JSON)
 
 runs:
-  using: 'node24' 
+  using: 'node24'
   main: 'dist/index.js'

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
       },
       "devDependencies": {
         "@types/jest": "^29.5.12",
-        "@types/node": "^20",
+        "@types/node": "^24.1.0",
         "@types/spdx-expression-parse": "^3.0.4",
         "@typescript-eslint/eslint-plugin": "^6.21.0",
         "@typescript-eslint/parser": "^6.21.0",
@@ -41,6 +41,9 @@
         "nodemon": "^3.1.10",
         "prettier": "3.6.2",
         "typescript": "^5.8.3"
+      },
+      "engines": {
+        "node": ">=24"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -2197,12 +2200,12 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.19.7",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.7.tgz",
-      "integrity": "sha512-1GM9z6BJOv86qkPvzh2i6VW5+VVrXxCLknfmTkWEqz+6DqosiY28XUWCTmBcJ0ACzKqx/iwdIREfo1fwExIlkA==",
+      "version": "24.1.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.1.0.tgz",
+      "integrity": "sha512-ut5FthK5moxFKH2T1CUOC6ctR67rQRvvHdFLCD2Ql6KXmMuCrjsSsRI9UsLCm9M18BMwClv4pn327UvB7eeO1w==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~7.8.0"
       }
     },
     "node_modules/@types/semver": {
@@ -7907,9 +7910,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
+      "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
       "license": "MIT"
     },
     "node_modules/universal-github-app-jwt": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "4.7.1",
   "private": true,
   "description": "A GitHub Action for Dependency Review",
+    "engines": {
+    "node": ">=24"
+  },
   "main": "lib/main.js",
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
@@ -43,7 +46,7 @@
   },
   "devDependencies": {
     "@types/jest": "^29.5.12",
-    "@types/node": "^20",
+    "@types/node": "^24.1.0",
     "@types/spdx-expression-parse": "^3.0.4",
     "@typescript-eslint/eslint-plugin": "^6.21.0",
     "@typescript-eslint/parser": "^6.21.0",


### PR DESCRIPTION
Bump the required Node.js version to 24 in action.yml and package.json. Update @types/node to 24.1.0 and adjust related dependencies and engines field to ensure compatibility.