### PR TITLE
encode url for package listed in allowed dependencies list

### DIFF
--- a/src/licenses.ts
+++ b/src/licenses.ts
@@ -41,7 +41,7 @@ export async function getInvalidLicenseChanges(
 
   const licenseExclusions = licenses.licenseExclusions?.map(
     (pkgUrl: string) => {
-      return parsePURL(pkgUrl)
+      return parsePURL(encodeURI(pkgUrl))
     }
   )
 
@@ -174,7 +174,7 @@ async function groupChanges(
         return true
       }
 
-      const changeAsPackageURL = parsePURL(encodeURI(change.package_url))
+      const changeAsPackageURL = parsePURL(change.package_url)
 
       // We want to find if the licenseExclusion list contains the PackageURL of the Change
       // If it does, we want to filter it out and therefore return false


### PR DESCRIPTION
Use EncodeUrl for packages listed in allowed-dependencies list. 
remove EncodeUrl for packages listed from GitHub dependency graph url as it's already Url Encoded

Fix #947 