### PR TITLE
Bump to 4.8.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dependency-review-action",
-  "version": "4.7.4",
+  "version": "4.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dependency-review-action",
-      "version": "4.7.4",
+      "version": "4.8.0",
       "license": "MIT",
       "dependencies": {
         "@actions/artifact": "^2.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dependency-review-action",
-  "version": "4.7.4",
+  "version": "4.8.0",
   "private": true,
   "description": "A GitHub Action for Dependency Review",
   "main": "lib/main.js",


### PR DESCRIPTION
The changes shipped very recently as 4.7.4 are reasonable significant, so we should likely be stricter on our use of semver and consider this a minor update rather than patch update.