### PR TITLE
Update README to include `allow-dependencies-licenses` example

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ You can pass configuration options to the dependency review action using your wo
 
              # Use comma-separated names to pass list arguments:
              deny-licenses: LGPL-2.0, BSD-2-Clause
+             allow-dependencies-licenses: "pkg:npm/@myorg/mypackage, pkg:npm/packagename, pkg:githubactions/owner/repo@2.0.0"
    ```
 
 #### Option 2: Using an external configuration file


### PR DESCRIPTION
I was recently working with a customer who needed help with setting up the DRA to use `deny-licenses` along with `allow-dependencies-licenses`.

The problems that came up were mainly how to specify GitHub Actions, as there is virtually no guidance on how to specify the PURL for an Action. We went through a long list of wrong ways to do it, including (but not limited to):

`pkg:github/org/action@v6`
`pkg:actions/org/action@^6.0.0`
`pkg:github/my-github-action`

Before landing on the right way only after inferring it from the dependency graph API.

I also add an example for scoped NPM packages as a nod to #1008.

This is just an idea, and totally appriciate if there's a better place for this so feedback/suggestions are welcome, but it's important that we have it somewhere.