### PR TITLE
Remove bad token reference

### DIFF
--- a/.github/workflows/ci-update-dist.yml
+++ b/.github/workflows/ci-update-dist.yml
@@ -22,8 +22,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-        with:
-          token: ${{ secrets.BOT_GITHUB_TOKEN }}
 
       - name: Set up Node.js
         uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0


### PR DESCRIPTION
## Purpose

The action to build the dist directory referenced a non-existing token.

## Related Issues
