### PR TITLE
fix: make the deny check respect pkg namespaces

### DIFF
--- a/__tests__/deny.test.ts
+++ b/__tests__/deny.test.ts
@@ -135,29 +135,44 @@ test('allows packages not defined in the deny packages and groups list', async (
   expect(deniedChanges.length).toEqual(0)
 })
 
+test('allows packages with the same name, but different namespaces', async () => {
+  const changes: Changes = [npmChange]
+  const deniedPackages = createTestPURLs([
+    'pkg:npm/lodasher/lodash',
+    'pkg:npm/malicious/lodash@4.17.20'
+  ])
+  const deniedChanges = await getDeniedChanges(changes, deniedPackages, [])
+
+  expect(deniedChanges.length).toEqual(0)
+})
+
 test('deny packages does not prevent removal of denied packages', async () => {
   const changes: Changes = [
     createTestChange({
       change_type: 'added',
       name: 'deny-by-name-and-version',
+      package_url: 'pkg:npm/org.test.deny.by/deny-by-name-and-version@1.0.0',
       version: '1.0.0',
       ecosystem: 'npm'
     }),
     createTestChange({
       change_type: 'removed',
       name: 'pass-by-name-and-version',
+      package_url: 'pkg:npm/org.test.pass.by/pass-by-name-and-version@1.0.0',
       version: '1.0.0',
       ecosystem: 'npm'
     }),
     createTestChange({
       change_type: 'added',
       name: 'deny-by-name',
+      package_url: 'pkg:npm/org.test.deny.by/deny-by-name',
       version: '1.0.0',
       ecosystem: 'npm'
     }),
     createTestChange({
       change_type: 'removed',
       name: 'pass-by-name',
+      package_url: 'pkg:npm/org.test.pass.by/pass-by-name',
       version: '1.0.0',
       ecosystem: 'npm'
     }),

--- a/src/deny.ts
+++ b/src/deny.ts
@@ -14,17 +14,19 @@ export async function getDeniedChanges(
       continue
     }
 
+    const namespace = getNamespace(change)
+
     for (const denied of deniedPackages) {
       if (
         (!denied.version || change.version === denied.version) &&
-        change.name === denied.name
+        change.name === denied.name &&
+        namespace === denied.namespace
       ) {
         changesDenied.push(change)
       }
     }
 
     for (const denied of deniedGroups) {
-      const namespace = getNamespace(change)
       if (!denied.namespace) {
         core.error(
           `Denied group represented by '${denied.original}' does not have a namespace. The format should be 'pkg:<type>/<namespace>/'.`


### PR DESCRIPTION
## Summary 
This adds a namespace condition into the deny check. This will fix an issue where the check would deny different packages than those actually provided.
Also adds a test for this and fixes one test present by providing package URLs.

## Testing steps
Steps to reproduce the behavior:
1. Go to any project with some packages.
    (ex.: a repo that has the valid `eslint` pkg as a dependency)
2. Have a config with a denied package, that has the same name, but a different namespace.
    (ex.: deny the malware `@typescript_eslinter/eslint` pkg)
3. Run the action.
4. Verify that it doesn't list the regular `eslint` as a denied package.


Closes: #1014