### PR TITLE
Update spdx-license-ids

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7988,9 +7988,9 @@
       }
     },
     "node_modules/spdx-license-ids": {
-      "version": "3.0.20",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.20.tgz",
-      "integrity": "sha512-jg25NiDV/1fLtSgEgyvVyDunvaNHbuwF9lfNV17gSmPFAlYzdfNBlLtLzXTevwkPj7DhGbmN9VnmJIgLnhvaBw==",
+      "version": "3.0.22",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.22.tgz",
+      "integrity": "sha512-4PRT4nh1EImPbt2jASOKHX7PB7I+e4IWNLvkKFDxNhJlfjbYlleYQh285Z/3mPTHSAK/AvdMmw5BNNuYH8ShgQ==",
       "license": "CC0-1.0"
     },
     "node_modules/spdx-ranges": {


### PR DESCRIPTION
## Summary

Updates the `spdx-license-ids` package from `3.0.20` to `3.0.22`.

## Motivation

The current version (`3.0.20`) does not recognize newer SPDX license identifiers such as `FSL-1.1-MIT`.
Bumping to `3.0.22` resolves this by including the latest set of valid SPDX license IDs.

## Changes

- `package-lock.json`: Bump `spdx-license-ids` from `3.0.20` to `3.0.22

