### PR TITLE
fix: output the actual PR comment in comment-content

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -242,7 +242,7 @@ async function run(): Promise<void> {
     summary.addScannedFiles(changes)
     printScannedDependencies(changes)
 
-    // include full summary in output; Actions will truncate if oversized
+    // PR comment/summary handling
     let rendered = core.summary.stringify()
 
     // Handle large summaries by uploading as artifact

--- a/src/main.ts
+++ b/src/main.ts
@@ -244,7 +244,6 @@ async function run(): Promise<void> {
 
     // include full summary in output; Actions will truncate if oversized
     let rendered = core.summary.stringify()
-    core.setOutput('comment-content', rendered)
 
     // Handle large summaries by uploading as artifact
     rendered = await handleLargeSummary(rendered)
@@ -256,6 +255,9 @@ async function run(): Promise<void> {
       )
       rendered = minSummary
     }
+
+    // Set the actual PR comment as output (minimal version if too large for a comment on GitHub)
+    core.setOutput('comment-content', rendered)
 
     // update the PR comment if needed with the right-sized summary
     await commentPr(rendered, config, issueFound)


### PR DESCRIPTION
This is either a small bug or a documentation issue, based on the name of output I would consider this a bug however.

The documentation states that the `comment-content` output should contain the same content as the comment. However the action has a fail-safe to prevent large comments (which can happen often when the OpenSSF scorecard is enabled) and falls back to a minimum comment. Currently the `comment-content` output always contains the full comment/summary.

This change fixes that by ensuring the `comment-content` output is set to the actual PR comment that this action would post (based on the `comment-summary-in-pr` input).

### My use-case
As I'm using the `comment-content` output to post a comment in a later step myself, it's hard to process when the comment is large. E.g. when using the output as an env var input in another step I frequently see errors such as:
`Error: An error occurred trying to start process '/usr/bin/bash' with working directory '/home/ubuntu/_work/xxxx/xxxx'. Argument list too long`
Which I think happens because the kernel's `ARG_MAX` is exceeded.

I just want to be able to access an actual postable comment so for me this works best. I hope you agree. :)

If you believe the full summary should be available as an output as well I would suggest adding another output called `summary-content` or similar.