### PR TITLE
fix: patched version display for advisories with non-strict semver ranges (e.g. Maven beta versions)

### DIFF
--- a/__tests__/summary.test.ts
+++ b/__tests__/summary.test.ts
@@ -696,6 +696,49 @@ test('addChangeVulnerabilitiesToSummary() - handles RestSharp GHSA-4rr6-2v9v-wcp
   })
 })
 
+test('addChangeVulnerabilitiesToSummary() - handles GHSA-vc5p-v9hr-52mj maven range', async () => {
+  const pkg = createTestChange({
+    ecosystem: 'maven',
+    name: 'org.apache.logging.log4j:log4j-core',
+    version: '2.12.4',
+    vulnerabilities: [
+      createTestVulnerability({
+        advisory_ghsa_id: 'GHSA-vc5p-v9hr-52mj',
+        advisory_summary: 'Apache Log4j vulnerable to XXE in JDBC Appender',
+        severity: 'high'
+      })
+    ]
+  })
+
+  // Mock API response from https://api.github.com/advisories/GHSA-vc5p-v9hr-52mj
+  mockOctokitRequest.mockResolvedValueOnce({
+    data: {
+      vulnerabilities: [
+        {
+          package: {
+            ecosystem: 'maven',
+            name: 'org.apache.logging.log4j:log4j-core'
+          },
+          vulnerable_version_range: '>= 2.0-beta9, < 2.25.3',
+          first_patched_version: '2.25.3'
+        }
+      ]
+    }
+  })
+
+  const changes = [pkg]
+  await summary.addChangeVulnerabilitiesToSummary(changes, 'low', true)
+
+  const text = core.summary.stringify()
+
+  // Should show the correct patched version for this advisory range
+  expect(text).toContain('2.25.3')
+  expect(text).not.toContain('N/A')
+  expect(mockOctokitRequest).toHaveBeenCalledWith('GET /advisories/{ghsa_id}', {
+    ghsa_id: 'GHSA-vc5p-v9hr-52mj'
+  })
+})
+
 test('addChangeVulnerabilitiesToSummary() - handles version coercion for non-strict semver versions', async () => {
   // Test that versions like "8.0" (without patch version) can be coerced to "8.0.0"
   // for successful range matching in fail-open mode (patch selection)
@@ -776,6 +819,50 @@ test('addChangeVulnerabilitiesToSummary() - handles invalid versions in fail-ope
 
   // Should show N/A since version can't be coerced or matched
   expect(text).toContain('N/A')
+})
+
+test('addChangeVulnerabilitiesToSummary() - handles GHSA-r9w3-57w2-gch2 go pseudo-version range', async () => {
+  const pkg = createTestChange({
+    ecosystem: 'go',
+    name: 'github.com/ory/hydra',
+    version: '2.1.0-pre.2',
+    vulnerabilities: [
+      createTestVulnerability({
+        advisory_ghsa_id: 'GHSA-r9w3-57w2-gch2',
+        advisory_summary:
+          'Ory Hydra has a SQL injection via forged pagination tokens',
+        severity: 'high'
+      })
+    ]
+  })
+
+  // Mock API response from https://api.github.com/advisories/GHSA-r9w3-57w2-gch2
+  mockOctokitRequest.mockResolvedValueOnce({
+    data: {
+      vulnerabilities: [
+        {
+          package: {
+            ecosystem: 'go',
+            name: 'github.com/ory/hydra'
+          },
+          vulnerable_version_range: '< 2.3.1-0.20260320110106-0b84568fffcc',
+          first_patched_version: '2.3.1-0.20260320110106-0b84568fffcc'
+        }
+      ]
+    }
+  })
+
+  const changes = [pkg]
+  await summary.addChangeVulnerabilitiesToSummary(changes, 'low', true)
+
+  const text = core.summary.stringify()
+
+  // Should show the correct patched version for this advisory range
+  expect(text).toContain('2.3.1-0.20260320110106-0b84568fffcc')
+  expect(text).not.toContain('N/A')
+  expect(mockOctokitRequest).toHaveBeenCalledWith('GET /advisories/{ghsa_id}', {
+    ghsa_id: 'GHSA-r9w3-57w2-gch2'
+  })
 })
 
 test('addChangeVulnerabilitiesToSummary() - respects concurrency limit for API calls', async () => {

--- a/src/summary.ts
+++ b/src/summary.ts
@@ -74,7 +74,7 @@ function versionInRange(
   // Validate version and range explicitly to enforce fail-closed semantics
   // semver.satisfies() typically returns false for invalid inputs without throwing
   let validVersion = semver.valid(trimmedVersion)
-  const validRange = semver.validRange(semverRange)
+  let validRange = semver.validRange(semverRange)
 
   // For fail-open mode (patch selection), try coercing invalid versions
   // to handle common real-world formats like "8.0", date-based versions, etc.
@@ -85,6 +85,26 @@ function versionInRange(
       core.debug(
         `Coerced version "${trimmedVersion}" to "${validVersion}" for range matching`
       )
+    }
+  }
+
+  // For fail-open mode, try coercing invalid version components within the range string
+  // to handle formats like "2.0-beta9" which should be "2.0.0-beta9" for strict semver
+  if (!validRange && !failClosed) {
+    const coercedRangeStr = semverRange.replace(
+      /(?<=[><=~^\s]|^)(\d+\.\d+(?:\.\d+)?(?:-[^\s]*)?)(?=\s|$)/g,
+      match => {
+        const coerced = semver.coerce(match)
+        return coerced ? coerced.version : match
+      }
+    )
+    if (coercedRangeStr !== semverRange) {
+      validRange = semver.validRange(coercedRangeStr)
+      if (validRange) {
+        core.debug(
+          `Coerced range "${semverRange}" to "${coercedRangeStr}" for range matching`
+        )
+      }
     }
   }
 


### PR DESCRIPTION
 When showing patched versions in the vulnerability summary, advisories with version ranges containing non-strict semver components — such as Maven's >= 2.0-beta9, < 2.25.3 — would display "N/A" instead of the correct patched version. This happened because semver.validRange() rejects range bounds like 2.0-beta9 (missing the patch segment, e.g. 2.0.0-beta9), causing the versionInRange function to fail range validation and fall through to its fail-open default of no match. The fix adds a coercion step in fail-open mode that rewrites invalid version components within the range string to their nearest valid semver equivalents (e.g. 2.0-beta9 → 2.0.0) before retrying validation, allowing the patched version lookup to succeed without affecting the fail-closed vulnerability detection path.

Adds test case for maven and another for golang for extra coverage

**Improvements to version range handling:**

* Enhanced the `versionInRange` function in `src/summary.ts` to attempt coercion of invalid version components within the range string for "fail-open" mode, improving support for non-strict semver formats (e.g., converting `2.0-beta9` to `2.0.0-beta9`) and increasing compatibility with real-world advisories.
* Refactored validation logic in `versionInRange` to use a mutable `validRange` variable, preparing for additional range coercion logic.

**Expanded test coverage for vulnerability summary logic:**

* Added a test for handling a Maven package advisory (`GHSA-vc5p-v9hr-52mj`) with a complex version range, ensuring the summary correctly identifies the patched version.
* Added a test for a Go package advisory (`GHSA-r9w3-57w2-gch2`) with a pseudo-version range, verifying correct patched version reporting and API usage.

Closes #1075 