### PR TITLE
docs: bump actions/checkout from v4 to v6 in workflow examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ You can install the action on any public repository, or any organization-owned p
        runs-on: ubuntu-latest
        steps:
          - name: 'Checkout Repository'
-           uses: actions/checkout@v4
+           uses: actions/checkout@v6
          - name: 'Dependency Review'
            uses: actions/dependency-review-action@v4
    ```
@@ -93,7 +93,7 @@ You can install the action on repositories on GitHub Enterprise Server.
        runs-on: self-hosted
        steps:
          - name: 'Checkout Repository'
-           uses: actions/checkout@v4
+           uses: actions/checkout@v6
          - name: 'Dependency Review'
            uses: actions/dependency-review-action@v4
    ```
@@ -162,7 +162,7 @@ You can pass configuration options to the dependency review action using your wo
        runs-on: ubuntu-latest
        steps:
          - name: 'Checkout Repository'
-           uses: actions/checkout@v4
+           uses: actions/checkout@v6
          - name: Dependency Review
            uses: actions/dependency-review-action@v4
            with:
@@ -189,7 +189,7 @@ You can use an external configuration file to specify settings for this action. 
        runs-on: ubuntu-latest
        steps:
          - name: 'Checkout Repository'
-           uses: actions/checkout@v4
+           uses: actions/checkout@v6
          - name: Dependency Review
            uses: actions/dependency-review-action@v4
            with:

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout Repository'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: 'Dependency Review'
         uses: actions/dependency-review-action@v4
 ```
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout Repository'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: 'Dependency Review'
         uses: actions/dependency-review-action@v4
         with:
@@ -76,7 +76,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout Repository'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: 'Dependency Review'
         uses: actions/dependency-review-action@v4
         with:
@@ -103,7 +103,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout Repository'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: 'Dependency Review'
         uses: actions/dependency-review-action@v4
         with:
@@ -130,7 +130,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout Repository'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: 'Dependency Review'
         uses: actions/dependency-review-action@v4
         with:
@@ -155,7 +155,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout Repository'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: 'Dependency Review'
         uses: actions/dependency-review-action@v4
         with:
@@ -182,7 +182,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout Repository'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: 'Dependency Review'
         id: review
         uses: actions/dependency-review-action@v4
@@ -226,7 +226,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout Repository'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: 'Dependency Review'
         uses: actions/dependency-review-action@v4
         with:
@@ -265,7 +265,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout Repository'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: 'Dependency Review'
         uses: actions/dependency-review-action@v4
         with:
@@ -295,7 +295,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout Repository'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: 'Dependency Review'
         uses: actions/dependency-review-action@v4
         with:
@@ -329,7 +329,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout Repository'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: 'Dependency Review'
         uses: actions/dependency-review-action@v4
         with:


### PR DESCRIPTION
## Summary

Update all `actions/checkout` references in `docs/examples.md` from `v4` to `v6`
to reflect the latest major version.

## Changes

- Updated 11 occurrences of `actions/checkout@v4` → `actions/checkout@v6` across
  all example workflow snippets.

## Motivation

The example workflows should reference the latest stable version of
`actions/checkout` so that users copying these snippets get up-to-date defaults.