### PR TITLE
Update Node.js runtime from 20 to 24

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -4,7 +4,7 @@ Trust these instructions. Only search the codebase if information here is incomp
 
 ## Repository Overview
 
-**dependency-review-action** is a GitHub Action (TypeScript/Node.js 20) that scans pull requests for dependency changes, raising errors for vulnerabilities or invalid licenses. It queries the GitHub Dependency Review API, evaluates changes against configured rules, and produces job summaries and PR comments. The action entry point is `dist/index.js` (bundled via `ncc`). The repo is small (~15 source files, ~15 test files).
+**dependency-review-action** is a GitHub Action (TypeScript/Node.js 24) that scans pull requests for dependency changes, raising errors for vulnerabilities or invalid licenses. It queries the GitHub Dependency Review API, evaluates changes against configured rules, and produces job summaries and PR comments. The action entry point is `dist/index.js` (bundled via `ncc`). The repo is small (~15 source files, ~15 test files).
 
 ## Build & Validation Commands
 
@@ -36,7 +36,7 @@ If format-check fails, run `npm run format` to auto-fix, then re-check.
 
 ### CI Checks (`.github/workflows/ci.yml`)
 
-CI runs on PRs (excluding `**.md` changes) with Node 20:
+CI runs on PRs (excluding `**.md` changes) with Node 24:
 
 1. **test** job: `npm ci --ignore-scripts` → `npm test`
 2. **lint** job: `npm ci --ignore-scripts` → `npm run format-check` → `npm run lint`
@@ -103,7 +103,7 @@ action.yml            # Action metadata — inputs, outputs, and `runs.main: dis
 
 ### Important Notes
 
-- The action runs on `node20` (declared in `action.yml`)
+- The action runs on `node24` (declared in `action.yml`)
 - Source imports often use relative `../src/` paths (e.g. `import {readConfig} from '../src/config'`)
 - Adding a new action input requires changes in: `action.yml` (input definition), `src/schemas.ts` (Zod schema with default), `src/config.ts` (reading the input), and relevant source/test files
 - `dist/index.js` is committed for GitHub Actions but PR contributors should NOT include `dist/` changes — maintainers handle rebuilding

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
       - name: Install dependencies
         run: npm ci --ignore-scripts
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
       - name: Install dependencies
         run: npm ci --ignore-scripts

--- a/action.yml
+++ b/action.yml
@@ -92,5 +92,5 @@ outputs:
     description: Denied dependency changes (JSON)
 
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
       },
       "devDependencies": {
         "@types/jest": "^29.5.14",
-        "@types/node": "^20",
+        "@types/node": "^24",
         "@types/spdx-expression-parse": "^3.0.4",
         "@typescript-eslint/eslint-plugin": "^6.21.0",
         "@typescript-eslint/parser": "^6.21.0",
@@ -2682,12 +2682,12 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.19.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.10.tgz",
-      "integrity": "sha512-iAFpG6DokED3roLSP0K+ybeDdIX6Bc0Vd3mLW5uDqThPWtNos3E+EqOM11mPQHKzfWHqEBuLjIlsBQQ8CsISmQ==",
+      "version": "24.12.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
+      "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~7.16.0"
       }
     },
     "node_modules/@types/semver": {
@@ -9110,9 +9110,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "license": "MIT"
     },
     "node_modules/universal-github-app-jwt": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   },
   "devDependencies": {
     "@types/jest": "^29.5.14",
-    "@types/node": "^20",
+    "@types/node": "^24",
     "@types/spdx-expression-parse": "^3.0.4",
     "@typescript-eslint/eslint-plugin": "^6.21.0",
     "@typescript-eslint/parser": "^6.21.0",


### PR DESCRIPTION
## Summary

- Update `action.yml` runtime from `node20` to `node24` (Node 20 is being deprecated, Node 24 is the latest LTS)
- Update CI workflows to use Node 24
- Update `@types/node` from `^20` to `^24`
- Update documentation references in `.github/copilot-instructions.md`

## Test plan

- [x] `npm run build` — compiles cleanly
- [x] `npm test` — all 188 tests pass
- [x] `npm run lint` — no issues
- [x] `npm run format-check` — all files formatted
- [x] `npm run package` — bundles successfully (no dist changes since no source logic changed)
