### PR TITLE
Bump spdx-license-ids from 3.0.20 to 3.0.23

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8472,9 +8472,9 @@
       }
     },
     "node_modules/spdx-license-ids": {
-      "version": "3.0.20",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.20.tgz",
-      "integrity": "sha512-jg25NiDV/1fLtSgEgyvVyDunvaNHbuwF9lfNV17gSmPFAlYzdfNBlLtLzXTevwkPj7DhGbmN9VnmJIgLnhvaBw==",
+      "version": "3.0.23",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.23.tgz",
+      "integrity": "sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==",
       "license": "CC0-1.0"
     },
     "node_modules/spdx-ranges": {


### PR DESCRIPTION
## Summary

- Bumps `spdx-license-ids` from `3.0.20` to `3.0.23`

## Motivation

The current version (`3.0.20`) does not recognize newer SPDX license identifiers such as `FSL-1.1-MIT`.
Bumping to `3.0.23` resolves this by including the latest set of valid SPDX license IDs.

This is a re-proposal of #1044 which was closed without being merged.

## Test plan

- [x] All 188 existing tests pass
- [x] Verified `FSL-1.1-MIT` is now recognized by the updated package

🤖 Generated with [Claude Code](https://claude.com/claude-code)