### PR TITLE
Update stale PR comment when on-failure issues have cleared

### DIFF
--- a/__tests__/comment-pr.test.ts
+++ b/__tests__/comment-pr.test.ts
@@ -1,0 +1,136 @@
+import {beforeEach, describe, expect, jest, test} from '@jest/globals'
+import {ConfigurationOptions} from '../src/schemas'
+
+// The octokit client is instantiated at module load in comment-pr.ts, so the
+// mock for @actions/github/lib/utils must expose a stable mock client that both
+// the module and the tests can reach.
+const octoMock = {
+  rest: {
+    issues: {
+      updateComment: jest.fn(),
+      createComment: jest.fn(),
+      listComments: jest.fn()
+    }
+  },
+  paginate: {
+    iterator: jest.fn()
+  }
+}
+
+jest.mock('@actions/github/lib/utils', () => ({
+  GitHub: {
+    plugin: () =>
+      function () {
+        return octoMock
+      }
+  },
+  getOctokitOptions: jest.fn(() => ({}))
+}))
+
+jest.mock('@actions/github', () => ({
+  context: {
+    payload: {pull_request: {number: 123}},
+    repo: {owner: 'owner', repo: 'repo'}
+  }
+}))
+
+jest.mock('@actions/core', () => ({
+  getInput: jest.fn(() => 'token'),
+  warning: jest.fn()
+}))
+
+import {commentPr} from '../src/comment-pr'
+
+const EXISTING_COMMENT_ID = 456
+const MARKER = '<!-- dependency-review-pr-comment-marker -->'
+
+function config(
+  comment_summary_in_pr: ConfigurationOptions['comment_summary_in_pr']
+): ConfigurationOptions {
+  return {comment_summary_in_pr} as ConfigurationOptions
+}
+
+// Makes paginate.iterator yield a single page of comments.
+function mockExistingComments(comments: {id: number; body: string}[]): void {
+  octoMock.paginate.iterator.mockReturnValue({
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    async *[Symbol.asyncIterator](): any {
+      yield {data: comments}
+    }
+  } as never)
+}
+
+describe('commentPr', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockExistingComments([])
+  })
+
+  describe("when comment_summary_in_pr is 'never'", () => {
+    test('does not create or update a comment', async () => {
+      await commentPr('summary', config('never'), true)
+
+      expect(octoMock.rest.issues.createComment).not.toHaveBeenCalled()
+      expect(octoMock.rest.issues.updateComment).not.toHaveBeenCalled()
+    })
+  })
+
+  describe("when comment_summary_in_pr is 'always'", () => {
+    test('creates a comment when none exists', async () => {
+      await commentPr('summary', config('always'), false)
+
+      expect(octoMock.rest.issues.createComment).toHaveBeenCalledTimes(1)
+      expect(octoMock.rest.issues.updateComment).not.toHaveBeenCalled()
+    })
+
+    test('updates the existing comment when one exists', async () => {
+      mockExistingComments([{id: EXISTING_COMMENT_ID, body: MARKER}])
+
+      await commentPr('summary', config('always'), false)
+
+      expect(octoMock.rest.issues.updateComment).toHaveBeenCalledTimes(1)
+      expect(octoMock.rest.issues.updateComment).toHaveBeenCalledWith(
+        expect.objectContaining({comment_id: EXISTING_COMMENT_ID})
+      )
+      expect(octoMock.rest.issues.createComment).not.toHaveBeenCalled()
+    })
+  })
+
+  describe("when comment_summary_in_pr is 'on-failure'", () => {
+    test('creates a comment when an issue is found and none exists', async () => {
+      await commentPr('summary', config('on-failure'), true)
+
+      expect(octoMock.rest.issues.createComment).toHaveBeenCalledTimes(1)
+    })
+
+    test('updates the existing comment when an issue is found', async () => {
+      mockExistingComments([{id: EXISTING_COMMENT_ID, body: MARKER}])
+
+      await commentPr('summary', config('on-failure'), true)
+
+      expect(octoMock.rest.issues.updateComment).toHaveBeenCalledWith(
+        expect.objectContaining({comment_id: EXISTING_COMMENT_ID})
+      )
+      expect(octoMock.rest.issues.createComment).not.toHaveBeenCalled()
+    })
+
+    test('updates the existing comment when issues have cleared', async () => {
+      mockExistingComments([{id: EXISTING_COMMENT_ID, body: MARKER}])
+
+      await commentPr('summary', config('on-failure'), false)
+
+      expect(octoMock.rest.issues.updateComment).toHaveBeenCalledTimes(1)
+      expect(octoMock.rest.issues.updateComment).toHaveBeenCalledWith(
+        expect.objectContaining({comment_id: EXISTING_COMMENT_ID})
+      )
+      expect(octoMock.rest.issues.createComment).not.toHaveBeenCalled()
+    })
+
+    test('does not create a comment when no issue is found and none exists', async () => {
+      await commentPr('summary', config('on-failure'), false)
+
+      expect(octoMock.rest.issues.createComment).not.toHaveBeenCalled()
+      expect(octoMock.rest.issues.updateComment).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/__tests__/comment-pr.test.ts
+++ b/__tests__/comment-pr.test.ts
@@ -53,7 +53,11 @@ function config(
 // Makes paginate.iterator yield a single page of comments.
 function mockExistingComments(comments: {id: number; body: string}[]): void {
   octoMock.paginate.iterator.mockReturnValue({
-    async *[Symbol.asyncIterator](): AsyncGenerator<{data: typeof comments}, void, unknown> {
+    async *[Symbol.asyncIterator](): AsyncGenerator<
+      {data: typeof comments},
+      void,
+      unknown
+    > {
       yield {data: comments}
       return
     }
@@ -114,14 +118,23 @@ describe('commentPr', () => {
       expect(octoMock.rest.issues.createComment).not.toHaveBeenCalled()
     })
 
-    test('updates the existing comment when issues have cleared', async () => {
+    test('updates the existing comment with a resolved note when issues have cleared', async () => {
       mockExistingComments([{id: EXISTING_COMMENT_ID, body: MARKER}])
 
       await commentPr('summary', config('on-failure'), false)
 
       expect(octoMock.rest.issues.updateComment).toHaveBeenCalledTimes(1)
       expect(octoMock.rest.issues.updateComment).toHaveBeenCalledWith(
-        expect.objectContaining({comment_id: EXISTING_COMMENT_ID})
+        expect.objectContaining({
+          comment_id: EXISTING_COMMENT_ID,
+          body: expect.stringContaining(
+            '✅ Previously flagged dependency issues have been resolved.'
+          )
+        })
+      )
+      // The full summary should not be re-posted in the resolved case.
+      expect(octoMock.rest.issues.updateComment).not.toHaveBeenCalledWith(
+        expect.objectContaining({body: expect.stringContaining('summary')})
       )
       expect(octoMock.rest.issues.createComment).not.toHaveBeenCalled()
     })

--- a/__tests__/comment-pr.test.ts
+++ b/__tests__/comment-pr.test.ts
@@ -53,11 +53,11 @@ function config(
 // Makes paginate.iterator yield a single page of comments.
 function mockExistingComments(comments: {id: number; body: string}[]): void {
   octoMock.paginate.iterator.mockReturnValue({
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    async *[Symbol.asyncIterator](): any {
+    async *[Symbol.asyncIterator](): AsyncGenerator<{data: typeof comments}, void, unknown> {
       yield {data: comments}
+      return
     }
-  } as never)
+  } as unknown as AsyncIterable<{data: typeof comments}>)
 }
 
 describe('commentPr', () => {

--- a/src/comment-pr.ts
+++ b/src/comment-pr.ts
@@ -17,7 +17,7 @@ const COMMENT_MARKER = '<!-- dependency-review-pr-comment-marker -->'
 
 // Body used to refresh a stale comment once previously-flagged issues are gone.
 const RESOLVED_MESSAGE =
-  '✅ Previously flagged dependency issues have been resolved.'
+  '# Dependency Review\n\n✅ Previously flagged dependency issues have been resolved.'
 
 export async function commentPr(
   commentContent: string,

--- a/src/comment-pr.ts
+++ b/src/comment-pr.ts
@@ -20,12 +20,19 @@ export async function commentPr(
   config: ConfigurationOptions,
   issueFound: boolean
 ): Promise<void> {
-  if (
-    !(
-      config.comment_summary_in_pr === 'always' ||
-      (config.comment_summary_in_pr === 'on-failure' && issueFound)
-    )
-  ) {
+  // Whether a comment should be posted (created if missing, updated if present).
+  const shouldComment =
+    config.comment_summary_in_pr === 'always' ||
+    (config.comment_summary_in_pr === 'on-failure' && issueFound)
+
+  // When configured to only comment on failure and no issue was found, we still
+  // want to update an existing comment from a previous failing run so it no
+  // longer shows stale failures once the issues have been resolved. We only
+  // update in this case, we never create a new comment.
+  const shouldUpdateExisting =
+    config.comment_summary_in_pr === 'on-failure' && !issueFound
+
+  if (!shouldComment && !shouldUpdateExisting) {
     return
   }
 
@@ -48,7 +55,7 @@ export async function commentPr(
         comment_id: existingCommentId,
         body: commentBody
       })
-    } else {
+    } else if (shouldComment) {
       await octo.rest.issues.createComment({
         owner: github.context.repo.owner,
         repo: github.context.repo.repo,

--- a/src/comment-pr.ts
+++ b/src/comment-pr.ts
@@ -15,24 +15,17 @@ const octo = new retryingOctokit(
 // Comment Marker to identify an existing comment to update, so we don't spam the PR with comments
 const COMMENT_MARKER = '<!-- dependency-review-pr-comment-marker -->'
 
+// Body used to refresh a stale comment once previously-flagged issues are gone.
+const RESOLVED_MESSAGE =
+  '✅ Previously flagged dependency issues have been resolved.'
+
 export async function commentPr(
   commentContent: string,
   config: ConfigurationOptions,
   issueFound: boolean
 ): Promise<void> {
-  // Whether a comment should be posted (created if missing, updated if present).
-  const shouldComment =
-    config.comment_summary_in_pr === 'always' ||
-    (config.comment_summary_in_pr === 'on-failure' && issueFound)
-
-  // When configured to only comment on failure and no issue was found, we still
-  // want to update an existing comment from a previous failing run so it no
-  // longer shows stale failures once the issues have been resolved. We only
-  // update in this case, we never create a new comment.
-  const shouldUpdateExisting =
-    config.comment_summary_in_pr === 'on-failure' && !issueFound
-
-  if (!shouldComment && !shouldUpdateExisting) {
+  // `never` is the only mode where we neither create nor update a comment.
+  if (config.comment_summary_in_pr === 'never') {
     return
   }
 
@@ -43,7 +36,16 @@ export async function commentPr(
     return
   }
 
-  const commentBody = `${commentContent}\n\n${COMMENT_MARKER}`
+  // In `on-failure` mode with no issues, we only refresh an existing comment
+  // from a previous failing run so it no longer shows stale failures — we never
+  // create a new one. In that case we replace the full summary with a short
+  // note rather than a large "no issues found" report.
+  const resolvedCleanup =
+    config.comment_summary_in_pr === 'on-failure' && !issueFound
+
+  const commentBody = `${
+    resolvedCleanup ? RESOLVED_MESSAGE : commentContent
+  }\n\n${COMMENT_MARKER}`
 
   try {
     const existingCommentId = await findCommentByMarker(COMMENT_MARKER)
@@ -55,7 +57,7 @@ export async function commentPr(
         comment_id: existingCommentId,
         body: commentBody
       })
-    } else if (shouldComment) {
+    } else if (config.comment_summary_in_pr === 'always' || issueFound) {
       await octo.rest.issues.createComment({
         owner: github.context.repo.owner,
         repo: github.context.repo.repo,


### PR DESCRIPTION
## Summary

Fixes #1127.

When `comment-summary-in-pr` is set to `on-failure`, the action posts a PR comment when a dependency review fails. Once the offending dependencies are fixed and the review passes, the commit status clears — but the failing PR comment was left behind, which is confusing.

This change makes `commentPr` update an existing comment when running in `on-failure` mode and no issues are found, so the comment reflects the resolved state instead of showing stale failures. A **new** comment is still never created in this case, so PRs that never had an issue stay noise-free (the behavior the `on-failure` option is designed for).

## Behavior matrix

| `comment-summary-in-pr` | issue found | existing comment | result |
|---|---|---|---|
| `never` | any | any | no comment (unchanged) |
| `always` | any | no | create (unchanged) |
| `always` | any | yes | update (unchanged) |
| `on-failure` | yes | no | create (unchanged) |
| `on-failure` | yes | yes | update (unchanged) |
| `on-failure` | **no** | **yes** | **update** ← fixed (was: left stale) |
| `on-failure` | no | no | no comment (unchanged) |

## Testing

Added `__tests__/comment-pr.test.ts` covering all of the cases above. Full suite (`npm test`), `npm run lint`, and `npm run format-check` all pass.

Note: `dist/` was intentionally not regenerated in this PR, matching the recent convention where the bundle is rebuilt at release time rather than per source change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)